### PR TITLE
Update en_US.properties

### DIFF
--- a/resources/micdoodle8/mods/galacticraft/core/client/lang/en_US.properties
+++ b/resources/micdoodle8/mods/galacticraft/core/client/lang/en_US.properties
@@ -258,6 +258,8 @@ gui.buggy.inv.name=Inventory / Fuel
 
 # DIMENSIONS
 dimension.Overworld.name=Overworld
+dimension.Moon.name=Moon
 dimension.Sun.name=Sun
+
 
 # </file>


### PR DESCRIPTION
Added "dimension.Moon.name" for Moon, because this string and translating of description of Moon are missing. Please, fix it.
