### PR TITLE
Added try-catch to naming an unknown enclosed pipe item.

### DIFF
--- a/common/micdoodle8/mods/galacticraft/core/items/GCCoreItemBlockEnclosedBlock.java
+++ b/common/micdoodle8/mods/galacticraft/core/items/GCCoreItemBlockEnclosedBlock.java
@@ -60,7 +60,14 @@ public class GCCoreItemBlockEnclosedBlock extends ItemBlock
             name = "aluminumWireHeavy";
             break;
         default:
-            name = GCCoreBlockEnclosed.getTypeFromMeta(par1ItemStack.getItemDamage()).getPipeClass();
+            try
+            {
+                name = GCCoreBlockEnclosed.getTypeFromMeta(par1ItemStack.getItemDamage()).getPipeClass();
+            }
+            catch(Exception e)
+            {
+                name = "null";
+            }
             break;
         }
 


### PR DESCRIPTION
Resolves a rare crash when the unlocalised name of an ItemBlockEnclosedBlock with an unsupported damagevalue is requested. Crash could occur when Galacticraft was loaded with mods that index items from other mods, for example Equivalent Exchange 3.

I think this is the only case of this problem, but I'm not sure.
