### PR TITLE
Fix for cheeseblock crash

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -148,8 +148,8 @@ public class GalacticraftCore
 			GCBlocks.fuelStill = GalacticraftCore.fluidFuel.getBlock();
 		}
 
-		GCItems.initItems();
 		GCBlocks.initBlocks();
+		GCItems.initItems();
 	}
 
 	@EventHandler


### PR DESCRIPTION
I did a little bit of searching through the code and found the problem for the cheeseblock crash. When the cheeseBlock-Item is "created" in GCItems.initItems(); it references the cheeseBlock-Block before it was created, causing a NullPointerException later. Switching these two lines solve the problem. I'm not entirely sure if this will break anything else though... I created this pull request so I could share my findings on the problem. This should fix #615

Forgive me if this pull request is a bad idea. I'm just trying to share my thoughts.
