### PR TITLE
Updated de_DE.lang for GC3 Mars

### DIFF
--- a/src/main/resources/assets/galacticraftmars/lang/de_DE.lang
+++ b/src/main/resources/assets/galacticraftmars/lang/de_DE.lang
@@ -11,7 +11,7 @@ item.slimelingCargo.name=Schleimling-Inventarbeutel
 item.key.T2.name=Dungeonschlüssel (Stufe 2)
 item.compressedDesh.name=Gepresstes Desh
 item.spaceshipTier2.cargoRocket.name=Güterrakete
-item.fluidManip.name=Fluid Manipulator ##NEEDS TRANSLATE##
+item.fluidManip.name=Flüssigkeit Manipulator
 
 # TOOLS
 item.deshPick.name=Desh-Spitzhacke
@@ -44,9 +44,9 @@ tile.slimelingEgg.yellowEgg.name=Gelbes Schleimling-Ei
 tile.marsMachine.0.name=Terraformer
 tile.marsMachine.1.name=Kryogene Kammer
 tile.marsMachine.2.name=Start-Controller
-tile.marsMachine.4.name=Gas Liquefier ##NEEDS TRANSLATE##
-tile.marsMachine.5.name=Methane Synthesizer ##NEEDS TRANSLATE##
-tile.marsMachine.6.name=Water Electrolyzer ##NEEDS TRANSLATE##
+tile.marsMachine.4.name=Gas Verflüssiger
+tile.marsMachine.5.name=Methan-Synthesizer
+tile.marsMachine.6.name=Wasser-Elektrolyseur
 tile.sludge.name=Bakterieller Schlamm
 tile.creeperEgg.name=Creeper-Ei
 tile.cavernVines.name=Kavernöse Weinranken
@@ -98,31 +98,31 @@ gui.message.redstoneSig.name=Redstone-Signal
 gui.message.notSet.name=Nicht eingestellt
 gui.message.notEnough.name=Nicht genug
 gui.message.success.name=Erfolg
-gui.launchController.desc.0=This is the Launch Controller's$unique frequency ##NEEDS TRANSLATE##
-gui.launchController.desc.1=Frequency to launch rockets towards ##NEEDS TRANSLATE##
-gui.launchController.desc.2=Whether the launch pad should$be removed on launch ##NEEDS TRANSLATE##
-gui.launchController.desc.3=When this criteria is met,$rocket will launch ##NEEDS TRANSLATE##
-gui.terraformer.desc.0=Water Tank ##NEEDS TRANSLATE##
-gui.gasTank.desc.0=Gas storage ##NEEDS TRANSLATE##
-gui.liquidTank.desc.0=Liquid Tank ##NEEDS TRANSLATE##
-gui.status.nogas.name=No gas ##NEEDS TRANSLATE##
-gui.status.liquefying.name=Liquefying ##NEEDS TRANSLATE##
-gui.status.needsCarbon.name=Needs carbon ##NEEDS TRANSLATE##
-gui.message.lowEnergy.name=Low energy ##NEEDS TRANSLATE##
-gui.button.liquefy.name=Process ##NEEDS TRANSLATE##
-gui.button.liquefyStop.name=Stop ##NEEDS TRANSLATE##
-gui.gasInput.desc.0=Try placing a Methane$Gas Canister here ##NEEDS TRANSLATE##
-gui.gasInput.desc.1=(Perhaps alternatively,$an Atmospheric Valve) ##NEEDS TRANSLATE##
-gui.hydrogenInput.desc.0=This takes a hydrogen tank ##NEEDS TRANSLATE##
-gui.hydrogenInput.desc.1=or an Atmospheric Valve ##NEEDS TRANSLATE##
-gui.liquidOutput.desc.2=liquefied gas tank ##NEEDS TRANSLATE##
-gui.methaneOutput.desc.2=methane tank ##NEEDS TRANSLATE##
-gui.message.withAtmosphere0.name=on a planet with plenty of ##NEEDS TRANSLATE##
-gui.message.withAtmosphere1.name=in the atmosphere ##NEEDS TRANSLATE##
-item.carbonFragments.name=Fragmented Carbon ##NEEDS TRANSLATE##
-gas.carbondioxide.name=Carbon Dioxide ##NEEDS TRANSLATE##
-gas.oxygen.name=Oxygen ##NEEDS TRANSLATE##
-gas.nitrogen.name=Nitrogen ##NEEDS TRANSLATE##
+gui.launchController.desc.0=Das ist der Start-Controller's$einmalige frequenz
+gui.launchController.desc.1=Frequenz fuer die Raketen zu starten
+gui.launchController.desc.2=Ob die rampe being start enfernt werden soll
+gui.launchController.desc.3=Wenn die Kriterien erfüllt sind,$Rakete wird starten
+gui.terraformer.desc.0=Wasser Tank
+gui.gasTank.desc.0=Gas Speicher
+gui.liquidTank.desc.0=Flüssigkeit Tank
+gui.status.nogas.name=Kein Gas
+gui.status.liquefying.name=Verflüssigen
+gui.status.needsCarbon.name=Braucht Karbon
+gui.message.lowEnergy.name=Geringe Energie
+gui.button.liquefy.name=Prozess
+gui.button.liquefyStop.name=Stop
+gui.gasInput.desc.0=Versuche einen Methan$Gas Kanister hier zu platzieren 
+gui.gasInput.desc.1=(Villeicht alternativ,$einen Atmosphärenventil)
+gui.hydrogenInput.desc.0=Dies nimmt einen wasserstoff-tank
+gui.hydrogenInput.desc.1=oder einen Atmosphärenventil
+gui.liquidOutput.desc.2=flüssiggastank
+gui.methaneOutput.desc.2=methan-tank
+gui.message.withAtmosphere0.name=auf einen planeten mit reichlich
+gui.message.withAtmosphere1.name=in der atmosphäre
+item.carbonFragments.name=Fragmentierte Karbon
+gas.carbondioxide.name=Kohlendioxid
+gas.oxygen.name=Sauerstoff
+gas.nitrogen.name=Stickstoff
 
 gui.desc.reinforcedPlateT2.name=Stufe 2
 
@@ -133,15 +133,15 @@ planet.mars=Mars
 
 # Schematics
 schematic.rocketT3.name=Rakete (Stufe 3)
-schematic.cargoRocket.name=Automatische Güterrakete
+schematic.cargoRocket.name=Automatische Güterrakete 
 
 # Entities
 entity.Sludgeling.name=Schlammling
 entity.Slimeling.name=Schleimling
 entity.CreeperBoss.name=Entwickelter Creeper-Boss
-entity.SpaceshipT2.name=Tier 2 Rocket ##NEEDS TRANSLATE##
-entity.CargoRocket.name=Cargo Rocket ##NEEDS TRANSLATE##
+entity.SpaceshipT2.name=Stufe 2 Rackete
+entity.CargoRocket.name=Automatische Güterrakete
 
 # Container
 container.launchcontroller.name=Start-Controller
-container.tileTerraformer.name=Terraformer ##NEEDS TRANSLATE##
+container.tileTerraformer.name=Landschaft Bearbeiter


### PR DESCRIPTION
No direct translation available for a Terraformer, using a rough translation for "Landscape Editor" instead.
