### PR TITLE
FIXED: Inventory keybinding crash

### DIFF
--- a/common/micdoodle8/mods/galacticraft/core/tick/GCCoreTickHandlerClient.java
+++ b/common/micdoodle8/mods/galacticraft/core/tick/GCCoreTickHandlerClient.java
@@ -51,6 +51,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.WorldProviderSurface;
 
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
 import tconstruct.client.tabs.TabRegistry;
@@ -375,7 +376,11 @@ public class GCCoreTickHandlerClient implements ITickHandler
 
 		if (type.equals(EnumSet.of(TickType.CLIENT)))
 		{
-			boolean invKeyPressed = Keyboard.isKeyDown(minecraft.gameSettings.keyBindInventory.keyCode);
+			boolean invKeyPressed = false;
+			if (minecraft.gameSettings.keyBindInventory.keyCode < 0)
+				invKeyPressed = Mouse.isButtonDown(minecraft.gameSettings.keyBindInventory.keyCode);
+			else
+				invKeyPressed = Keyboard.isKeyDown(minecraft.gameSettings.keyBindInventory.keyCode);
 
 			if (!GCCoreTickHandlerClient.lastInvKeyPressed && invKeyPressed && minecraft.currentScreen != null && minecraft.currentScreen.getClass() == GuiInventory.class)
 			{


### PR DESCRIPTION
It is impossible for keyboard key codes to be negative, most that are negative are mouse codes. Easy fix, this helps people that get a permanent crash if their inventory key binding is set to any mouse buttons.
