### PR TITLE
Fixed short range teleport not giving item

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/blocks/BlockShortRangeTelepad.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/blocks/BlockShortRangeTelepad.java
@@ -20,6 +20,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
@@ -115,7 +116,7 @@ public class BlockShortRangeTelepad extends BlockTileGC implements ItemBlockDesc
             {
                 ((EntityPlayer) entityLiving).addChatMessage(new ChatComponentText(EnumColor.RED + GCCoreUtil.translate("gui.warning.noroom")));
             }
-
+	    ((EntityPlayer) entityLiving).inventory.addItemStackToInventory(new ItemStack(Item.getItemFromBlock(this), 1, 0));
             return;
         }
 


### PR DESCRIPTION
If placed block in a small room. It's not giving item when not enough room.
