### PR TITLE
Don't skip frequency checks if tilelist is updated

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityAutoRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityAutoRocket.java
@@ -232,15 +232,13 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements ID
         {
             WorldServer world = FMLCommonHandler.instance().getMinecraftServerInstance().worldServers[i];
 
-            for (int j = 0; j < world.loadedTileEntityList.size(); j++)
+            for (TileEntity tile : new ArrayList<TileEntity>(world.loadedTileEntityList))
             {
-            	TileEntity tile = (TileEntity) world.loadedTileEntityList.get(j);
-            	
             	if (tile != null)
                 {
                     tile = world.getTileEntity(tile.xCoord, tile.yCoord, tile.zCoord);
                     if (tile == null) continue;
-                    
+
                     try
                     {
                         Class<?> controllerClass = Class.forName("micdoodle8.mods.galacticraft.planets.mars.tile.TileEntityLaunchController");

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntityLaunchController.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntityLaunchController.java
@@ -331,12 +331,13 @@ public class TileEntityLaunchController extends TileBaseElectricBlockWithInvento
             {
                 WorldServer world = FMLCommonHandler.instance().getMinecraftServerInstance().worldServers[i];
 
-                for (int j = 0; j < world.loadedTileEntityList.size(); j++)
+                for (TileEntity tile2 : new ArrayList<TileEntity>(world.loadedTileEntityList))
                 {
-                	TileEntity tile2 = (TileEntity) world.loadedTileEntityList.get(j);
                     if (this != tile2)
                     {
                         tile2 = world.getTileEntity(tile2.xCoord, tile2.yCoord, tile2.zCoord);
+                        if (tile2 == null)
+                            continue;
 
                         if (tile2 instanceof TileEntityLaunchController)
                         {
@@ -379,12 +380,13 @@ public class TileEntityLaunchController extends TileBaseElectricBlockWithInvento
                 {
                     WorldServer world = FMLCommonHandler.instance().getMinecraftServerInstance().worldServers[i];
 
-                    for (int j = 0; j < world.loadedTileEntityList.size(); j++)
+                    for (TileEntity tile2 : new ArrayList<TileEntity>(world.loadedTileEntityList))
                     {
-                    	TileEntity tile2 = (TileEntity) world.loadedTileEntityList.get(j);
                         if (this != tile2)
                         {
                             tile2 = world.getTileEntity(tile2.xCoord, tile2.yCoord, tile2.zCoord);
+                            if (tile2 == null)
+                                continue;
 
                             if (tile2 instanceof TileEntityLaunchController)
                             {


### PR DESCRIPTION
Partially reapply ca84762e0eb689da0f74e7cbcb96ff4a13d7ecdd and revert
f88102ea44d83821372ddd8e60cf59ff45a12dbf

Despite the revert, it still fixes #1135 .
