### PR TITLE
Scramble the destination of the launch controller

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/element/GuiElementTextBox.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/element/GuiElementTextBox.java
@@ -240,6 +240,10 @@ public class GuiElementTextBox extends GuiButton
         }
     }
 
+    public int getMaxLength() {
+        return maxLength;
+    }
+
     public static interface ITextBoxCallback
     {
         public boolean canPlayerEdit(GuiElementTextBox textBox, EntityPlayer player);

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/gui/GuiLaunchController.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/gui/GuiLaunchController.java
@@ -20,6 +20,7 @@ import micdoodle8.mods.galacticraft.planets.mars.inventory.ContainerLaunchContro
 import micdoodle8.mods.galacticraft.planets.mars.network.PacketSimpleMars;
 import micdoodle8.mods.galacticraft.planets.mars.network.PacketSimpleMars.EnumSimplePacketMars;
 import micdoodle8.mods.galacticraft.planets.mars.tile.TileEntityLaunchController;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiLabel;
 import net.minecraft.client.renderer.RenderHelper;
@@ -27,12 +28,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ChatAllowedCharacters;
 import net.minecraft.util.ResourceLocation;
+
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 public class GuiLaunchController extends GuiContainerGC implements IDropboxCallback, ITextBoxCallback, ICheckBoxCallback
 {
@@ -351,7 +354,21 @@ public class GuiLaunchController extends GuiContainerGC implements IDropboxCallb
         }
         else if (textBox.equals(this.destinationFrequency))
         {
-            return String.valueOf(this.launchController.destFrequency);
+            if (Minecraft.getMinecraft().thePlayer.getGameProfile().getName().equals(this.launchController.getOwnerName()))
+            {
+                return String.valueOf(this.launchController.destFrequency);
+            }
+            else
+            {
+                // in case the player is not equal to the owner of the controller,
+                // scramble the destination number such that other players can't
+                // fly to it directly
+                Random r = new Random();
+                String fakefrequency = "";
+                for (int i = 0; i < this.destinationFrequency.getMaxLength(); i++)
+                    fakefrequency += (char) (r.nextInt(126 - 33) + 33);
+                return fakefrequency;
+            }
         }
 
         return "";


### PR DESCRIPTION
Currently, it is possible to fly to other player's space station with a launch controller if a player forgot to remove the destination ID. This scrambles the ID of the launch controller and it will be impossible to see where you are going.
It will still be possible to use the launch controller and look at the destination's controller. But it's easy to scramble that one too, in case you are interested.

![scrambler](https://cloud.githubusercontent.com/assets/293499/4621517/633fc28a-532c-11e4-8259-5e407075e6f9.png)

Of course, it might be better to add a check to see if the player are in the same space race team. Or add a button which completely locks off players of other space race teams, but this was the easiest implementation I could think if.

This circumvention is just something which bugged me for a long time.