### PR TITLE
Allow external solar systems to be used.

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/galaxies/SolarSystem.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/galaxies/SolarSystem.java
@@ -48,6 +48,7 @@ public class SolarSystem
 
     public SolarSystem setMapPosition(Vector3 mapPosition)
     {
+    	mapPosition.scale(500D);
         this.mapPosition = mapPosition;
         return this;
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/screen/GameScreenCelestial.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/screen/GameScreenCelestial.java
@@ -129,9 +129,17 @@ public class GameScreenCelestial implements IGameScreen
         {
         	if (planet.getParentSolarSystem() != null && planet.getBodyIcon() != null)
             {
-                Vector3f pos = this.getCelestialBodyPosition(planet, ticks);
-                this.drawCircle(planet);
-        		this.drawCelestialBody(planet, pos.x, pos.y, ticks, (planet.getRelativeDistanceFromCenter().unScaledDistance < 1.5F) ? 2F : 2.8F);
+        		String status = planet.getUnlocalizedName() + " - " + planet.getParentSolarSystem().getUnlocalizedName() + " - ";
+        		boolean isMain = planet.getParentSolarSystem().getUnlocalizedName().equalsIgnoreCase(GalacticraftCore.solarSystemSol.getUnlocalizedName());
+        		status = status + isMain;
+//        		System.out.println(status);
+        		
+        		if(isMain)
+        		{
+        			Vector3f pos = this.getCelestialBodyPosition(planet, ticks);
+                    this.drawCircle(planet);
+            		this.drawCelestialBody(planet, pos.x, pos.y, ticks, (planet.getRelativeDistanceFromCenter().unScaledDistance < 1.5F) ? 2F : 2.8F);
+        		}
             }
         }
     }


### PR DESCRIPTION
I noticed that when creating an external solar system, the .getMapPosition was not been used at all, causing all the solar systems to be positioned on top of each other. I've tried to add a way to change this to make the solar systems be positioned away from each other, although it's probably not the best way to do it. This is a simple change to allow for basic solar systems to work, although I can imagine you want to change it up to make it easier to use, as you know your mod much better than me ;)

I had some derps with GitHub when trying to create this pull request. My GitHub client seemed to have issues with finding the files on my local system. I think these are the only files I've needed to change, although I'm not sure.
