### PR TITLE
Compatibility fix

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
@@ -64,7 +64,7 @@ import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.biome.BiomeGenDesert;
 import net.minecraftforge.client.event.sound.PlaySoundEvent17;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.living.PlayerDropsEvent;
+import net.minecraftforge.event.entity.player.PlayerDropsEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
@@ -64,7 +64,7 @@ import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.biome.BiomeGenDesert;
 import net.minecraftforge.client.event.sound.PlaySoundEvent17;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.living.PlayerDropsEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
@@ -570,7 +570,7 @@ public class EventHandlerGC
     }
 
     @SubscribeEvent
-    public void onPlayerDeath(LivingDeathEvent event)
+    public void onPlayerDeath(PlayerDropsEvent event)
     {
         if (event.entityLiving instanceof EntityPlayerMP)
         {


### PR DESCRIPTION
Change "LivingDeathEvent" to "PlayerDropsEvent". It will be called at Player death instead of when it reach 0 health points. This changes requires for "Gravestone mod" to trigger its event first.