### PR TITLE
Fix NPE crash at EntityLanderBase#444

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/InventoryEntity.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/InventoryEntity.java
@@ -9,7 +9,7 @@ import net.minecraft.world.World;
 
 public abstract class InventoryEntity extends NetworkedEntity implements IInventory
 {
-    public ItemStack[] containedItems;
+    public ItemStack[] containedItems = new ItemStack[0];
 
     public InventoryEntity(World par1World)
     {


### PR DESCRIPTION
Fixed a NullPointerException at EntityLanderBase line 444. Please do something like this everywhere. Initializing it later is fine, but _don't_ make it null. (For example, EntityAutoRocket.cargoItems)
