### PR TITLE
Change aluminumBlock to blockAluminum, support BigReactors

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemBlockBase.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemBlockBase.java
@@ -61,7 +61,7 @@ public class ItemBlockBase extends ItemBlockDesc
             name = "tinBlock";
             break;
         case 11:
-            name = "aluminumBlock";
+            name = "blockAluminum";
             break;
         case 12:
             name = "meteorironBlock";


### PR DESCRIPTION
BigReactors looks for blockAluminum for use as a coil material in turbines and a heat conductor in reactors.
Not sure this is the proper way to do this, but if not then blame me.