### PR TITLE
Fix lighting in extended inventory

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiExtendedInventory.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiExtendedInventory.java
@@ -8,6 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
@@ -118,6 +119,7 @@ public class GuiExtendedInventory extends InventoryEffectRenderer
         float f5 = par0Minecraft.thePlayer.rotationYawHead;
         par4 -= 19;
         GL11.glRotatef(135.0F, 0.0F, 1.0F, 0.0F);
+        RenderHelper.enableStandardItemLighting();
         GL11.glRotatef(-135.0F, 0.0F, 1.0F, 0.0F);
         // GL11.glRotatef(-((float) Math.atan(par5 / 40.0F)) * 20.0F, 1.0F,
         // 0.0F, 0.0F);


### PR DESCRIPTION
Please let's me know if this conflict with something.

Before
![2558-05-19_00 00 57](https://cloud.githubusercontent.com/assets/6128413/7724303/b9a92b6c-ff1a-11e4-908f-41369a14705a.png)

After
![2558-05-19_00 00 46](https://cloud.githubusercontent.com/assets/6128413/7724319/db2d9aca-ff1a-11e4-9d82-3a993c17ab41.png)
