### PR TITLE
fixed duplicate planets on live galaxyregistry refresh

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/galaxies/GalaxyRegistry.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/galaxies/GalaxyRegistry.java
@@ -61,6 +61,7 @@ public class GalaxyRegistry
     {
         GalaxyRegistry.moonList.clear();
         GalaxyRegistry.satelliteList.clear();
+        GalaxyRegistry.solarSystemList.clear();
 
         for (Moon moon : GalaxyRegistry.getRegisteredMoons().values())
         {


### PR DESCRIPTION
I was playing around with dynamic solar system generation and came over a weird bug where planets are duplicated in the GuiCelestialSelection when GalaxyRegistry.refreshGalaxies is called. Looks like you forgot to clear the third hashmap in there.