### PR TITLE
Add data field change tracking to reduce bandwidth usage

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/network/NetworkUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/network/NetworkUtil.java
@@ -1,5 +1,6 @@
 package micdoodle8.mods.galacticraft.core.network;
 
+import com.google.common.math.DoubleMath;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
@@ -494,5 +495,61 @@ public class NetworkUtil
         }
 
         return fluidTank;
+    }
+
+    public static boolean fuzzyEquals(Object a, Object b)
+    {
+        if ((a == null) != (b == null))
+        {
+            return false;
+        }
+        else if (a == null)
+        {
+            return true;
+        }
+        else if (a instanceof Float && b instanceof Float)
+        {
+            return DoubleMath.fuzzyEquals((Float) a, (Float) b, 0.01);
+        }
+        else if (a instanceof Double && b instanceof Double)
+        {
+            return DoubleMath.fuzzyEquals((Double) a, (Double) b, 0.01);
+        }
+        else if (a instanceof Entity && b instanceof Entity)
+        {
+            Entity a2 = (Entity) a;
+            Entity b2 = (Entity) b;
+            return fuzzyEquals(a2.getEntityId(), b2.getEntityId());
+        }
+        else if (a instanceof Vector3 && b instanceof Vector3)
+        {
+            Vector3 a2 = (Vector3) a;
+            Vector3 b2 = (Vector3) b;
+            return fuzzyEquals(a2.x, b2.x) &&
+                    fuzzyEquals(a2.y, b2.y) &&
+                    fuzzyEquals(a2.z, b2.z);
+        }
+        else if (a instanceof EnergyStorage && b instanceof EnergyStorage)
+        {
+            EnergyStorage a2 = (EnergyStorage) a;
+            EnergyStorage b2 = (EnergyStorage) b;
+            return fuzzyEquals(a2.getCapacityGC(), b2.getCapacityGC()) &&
+                    fuzzyEquals(a2.getMaxReceive(), b2.getMaxReceive()) &&
+                    fuzzyEquals(a2.getMaxExtract(), b2.getMaxExtract());
+        }
+        else if (a instanceof FluidTank && b instanceof FluidTank)
+        {
+            FluidTank a2 = (FluidTank) a;
+            FluidTank b2 = (FluidTank) b;
+            FluidStack fluidA = a2.getFluid();
+            FluidStack fluidB = b2.getFluid();
+            return fuzzyEquals(a2.getCapacity(), b2.getCapacity()) &&
+                    fuzzyEquals(fluidA != null ? fluidA.fluidID : -1, fluidB != null ? fluidB.fluidID : -1) &&
+                    fuzzyEquals(a2.getFluidAmount(), b2.getFluidAmount());
+        }
+        else
+        {
+            return a.equals(b);
+        }
     }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/wrappers/FlagData.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/wrappers/FlagData.java
@@ -5,6 +5,7 @@ import micdoodle8.mods.galacticraft.core.util.ColorUtil;
 import net.minecraft.nbt.NBTTagCompound;
 
 import java.awt.image.BufferedImage;
+import java.util.Arrays;
 
 public class FlagData
 {
@@ -154,4 +155,18 @@ public class FlagData
         }
         return image;
     }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FlagData flagData = (FlagData) o;
+
+        if (height != flagData.height) return false;
+        if (width != flagData.width) return false;
+        return Arrays.deepEquals(color, flagData.color);
+    }
+
 }


### PR DESCRIPTION
When we first tested GC and placed down some blocks 2 months ago, we were noticing excessive bandwidth usage (>5 mbit/s) and it was kicking some of us off due to overflow.

However, I was unable to find any reports of the issue on the Internet.

I traced our problem to some TEs that were presumably sending their data constantly to the client and I created the included patches. We applied them to our modpack and server and it seemed to have (mostly) abated our bandwidth usage problems for the past month and a half.

This PR makes some changes to EntityAdvanced and TileEntityAdvanced so that it keeps track of the previous values sent and only sends off a packet if there were changes detected. It would not reduce high bandwidth usage if data is changing often, but it reduces idle bandwidth usage (in theory).

With that in mind,

1. I don't know if other people experience this problem, but the changes did fix things for us.
2. I am not too familiar with GC, nor how its code is structured, so I don't know if this -- if the problem even exists -- would be the best approach to solving this issue.