### PR TITLE
Make TickHandlerServer.onWorldTick() faster

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerServer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerServer.java
@@ -481,9 +481,9 @@ public class TickHandlerServer
 
             if (changeList != null && !changeList.isEmpty())
             {
-                CopyOnWriteArrayList<ScheduledBlockChange> newList = new CopyOnWriteArrayList<ScheduledBlockChange>();
                 int blockCount = 0;
                 int blockCountMax = Math.max(this.MAX_BLOCKS_PER_TICK, changeList.size() / 4);
+                List<ScheduledBlockChange> newList = new ArrayList<ScheduledBlockChange>(Math.max(0, changeList.size() - blockCountMax));
 
                 for (ScheduledBlockChange change : changeList)
                 {
@@ -508,7 +508,7 @@ public class TickHandlerServer
 
                 changeList.clear();
                 TickHandlerServer.scheduledBlockChanges.remove(world.provider.dimensionId);
-                if (newList.size() > 0) TickHandlerServer.scheduledBlockChanges.put(world.provider.dimensionId, newList);
+                if (newList.size() > 0) TickHandlerServer.scheduledBlockChanges.put(world.provider.dimensionId, new CopyOnWriteArrayList<ScheduledBlockChange>(newList));
             }
 
             CopyOnWriteArrayList<BlockVec3> torchList = TickHandlerServer.scheduledTorchUpdates.get(world.provider.dimensionId);


### PR DESCRIPTION
Once in a blue moon, our server freezes up for a solid 30+ seconds in onWorldTick(). A few stack dumps have pointed to the CopyOnWriteArrayList used to store pending block changes:

```
    at java.util.Arrays.copyOf(Arrays.java:3181)
    at java.util.concurrent.CopyOnWriteArrayList.add(CopyOnWriteArrayList.java:439)
    at micdoodle8.mods.galacticraft.core.tick.TickHandlerServer.onWorldTick(TickHandlerServer.java:492)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler_984_TickHandlerServer_onWorldTick_WorldTickEvent.invoke(.dynamic)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
    at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:138)
    at cpw.mods.fml.common.FMLCommonHandler.onPreWorldTick(FMLCommonHandler.java:268)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:620)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
    at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```

This change defers creation of the CopyOnWriteArrayList to the end of the method, after the list has already been compiled. A temporary ArrayList pre-sized to the expected number of elements is used to build the list.

I'm not quite sure why CopyOnWriteArrayList is used to begin with, since scheduleNewBlockChange() and what not are not thread safe, but that's a more major change.