### PR TITLE
Prevent division by zero with thermalLevelTickCooldownSingle

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
@@ -494,6 +494,12 @@ public class GCPlayerHandler
                 //      by a small amount each time (still the same average increase/decrease)
                 int thermalLevelTickCooldownSingle = (int)Math.floor(thermalLevelTickCooldown / Math.abs(thermalLevelMod));
 
+                // Prevent "thermalLevelTickCooldownSingle" be less then 1
+                //      and prevent "/ 0" exception to be thrown in the next if statement
+                if (thermalLevelTickCooldownSingle == 0) {
+                    thermalLevelTickCooldownSingle = 1;
+                }
+
                 if ((player.ticksExisted - 1) % thermalLevelTickCooldownSingle == 0)
                 {
                     int last = playerStats.thermalLevel;


### PR DESCRIPTION
Prevent division by zero with thermalLevelTickCooldownSingle in case thermalLevelMod significantly bigger/less.

Issue occurs when using mod MorePlanets on Venus, that is hot :D
