### PR TITLE
Fix slot packet exception

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/inventory/SlotRocketBench.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/inventory/SlotRocketBench.java
@@ -43,7 +43,7 @@ public class SlotRocketBench extends Slot
 
                     if (var14 * var14 + var16 * var16 + var18 * var18 < 20 * 20)
                     {
-                        GalacticraftCore.packetPipeline.sendTo(new PacketSimple(EnumSimplePacket.C_SPAWN_SPARK_PARTICLES, FMLClientHandler.instance().getClient().theWorld.provider.getDimensionId(), new Object[] { this.pos }), var13);
+                        GalacticraftCore.packetPipeline.sendTo(new PacketSimple(EnumSimplePacket.C_SPAWN_SPARK_PARTICLES, FMLClientHandler.instance().getClient().theWorld.provider.getDimensionId(), new Object[] { this.pos.getX(), this.pos.getY(), this.pos.getZ() }), var13);
                     }
                 }
             }


### PR DESCRIPTION
Here is an error log.

[15:41:22] [Server thread/INFO] [Galacticraft]: Simple Packet Core found data length different than packet type
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: java.lang.RuntimeException
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at micdoodle8.mods.galacticraft.core.network.PacketSimple.<init>(PacketSimple.java:210)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at micdoodle8.mods.galacticraft.core.network.PacketSimple.<init>(PacketSimple.java:201)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at micdoodle8.mods.galacticraft.core.inventory.SlotRocketBench.onSlotChanged(SlotRocketBench.java:46)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.inventory.Container.slotClick(Container.java:386)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.network.NetHandlerPlayServer.processClickWindow(NetHandlerPlayServer.java:1045)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.network.play.client.C0EPacketClickWindow.processPacket(C0EPacketClickWindow.java:46)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.network.play.client.C0EPacketClickWindow.processPacket(C0EPacketClickWindow.java:11)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.network.PacketThreadUtil$1.run(PacketThreadUtil.java:15)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at java.util.concurrent.FutureTask.run(Unknown Source)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.util.Util.runTask(Util.java:22)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:736)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:681)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:159)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:548)
[15:41:22] [Server thread/INFO] [STDERR]: [micdoodle8.mods.galacticraft.core.network.PacketSimple:<init>:210]: 	at java.lang.Thread.run(Unknown Source)