### PR TITLE
Fixes server crash when Overworld id is not 0

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -393,7 +393,7 @@ public class WorldUtil
 
     public static void initialiseDimensionNames()
     {
-    	WorldProvider provider = WorldUtil.getProviderForDimensionServer(0);
+    	WorldProvider provider = WorldUtil.getProviderForDimensionServer(ConfigManagerCore.idDimensionOverworld);
     	WorldUtil.dimNames.put(ConfigManagerCore.idDimensionOverworld, new String(provider.getDimensionName()));
     }
     


### PR DESCRIPTION
When the overworld dimension is set to an different id than 0, this code takes the wrong provider to get the name.
So when the overworld is also called different, this will crash the server, when trying to reenter the "Overworld" from a planet.

Maybe related: #2242

Should fix #2243