### PR TITLE
Added config settings for separately enabling parts of challenge mode

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/GalacticraftConfigAccess.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/GalacticraftConfigAccess.java
@@ -7,6 +7,10 @@ public class GalacticraftConfigAccess
 	private static Field quickMode;
 	private static Field hardMode;
 	private static Field adventureMode;
+	private static Field adventureRecipes;
+	private static Field adventureMobDropsAndSpawning;
+	private static Field adventureSpawnHandling;
+	private static Field adventureAsteroidPopulation;
 	
 	public static boolean getQuickMode()
 	{
@@ -41,6 +45,50 @@ public class GalacticraftConfigAccess
 		return false;
 	}
 	
+	public static boolean getChallengeRecipes()
+	{
+		if (quickMode == null)
+			setup();
+		
+		try {
+			return (boolean) adventureRecipes.getBoolean(null);
+		} catch (Exception e) { }
+		return false;
+	}
+	
+	public static boolean getChallengeMobDropsAndSpawning()
+	{
+		if (quickMode == null)
+			setup();
+		
+		try {
+			return (boolean) adventureMobDropsAndSpawning.getBoolean(null);
+		} catch (Exception e) { }
+		return false;
+	}
+	
+	public static boolean getChallengeSpawnHandling()
+	{
+		if (quickMode == null)
+			setup();
+		
+		try {
+			return (boolean) adventureSpawnHandling.getBoolean(null);
+		} catch (Exception e) { }
+		return false;
+	}
+	
+	public static boolean getChallengeAsteroidPopulation()
+	{
+		if (quickMode == null)
+			setup();
+		
+		try {
+			return (boolean) adventureAsteroidPopulation.getBoolean(null);
+		} catch (Exception e) { }
+		return false;
+	}
+	
 	private static void setup()
 	{
 		try {
@@ -48,6 +96,10 @@ public class GalacticraftConfigAccess
 			quickMode = GCConfig.getField("quickMode");
 			hardMode = GCConfig.getField("hardMode");
 			adventureMode = GCConfig.getField("challengeMode");
+			adventureRecipes = GCConfig.getField("challengeRecipes");
+			adventureMobDropsAndSpawning = GCConfig.getField("challengeMobDropsAndSpawning");
+			adventureSpawnHandling = GCConfig.getField("challengeSpawnHandling");
+			adventureAsteroidPopulation = GCConfig.getField("challengeAsteroidPopulation");
 		} catch (Exception e) { e.printStackTrace(); }
 	}
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/CompressorRecipes.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/CompressorRecipes.java
@@ -341,7 +341,7 @@ public class CompressorRecipes
 
     public static List<IRecipe> getRecipeList()
     {
-    	return GalacticraftConfigAccess.getChallengeMode() ? CompressorRecipes.recipesAdventure : CompressorRecipes.recipes;
+    	return (GalacticraftConfigAccess.getChallengeMode() || GalacticraftConfigAccess.getChallengeRecipes()) ? CompressorRecipes.recipesAdventure : CompressorRecipes.recipes;
     }
     
     public static void removeRecipe(ItemStack match)

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedCreeper.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedCreeper.java
@@ -199,7 +199,7 @@ public class EntityEvolvedCreeper extends EntityCreeper implements IEntityBreath
             this.entityDropItem(new ItemStack(Blocks.ice), 0.0F);
             break;
         default:
-        	if (ConfigManagerCore.challengeMode) this.dropItem(Items.reeds, 1);
+        	if (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) this.dropItem(Items.reeds, 1);
         	break;
         }
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedSkeleton.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedSkeleton.java
@@ -135,7 +135,7 @@ public class EntityEvolvedSkeleton extends EntitySkeleton implements IEntityBrea
                 this.entityDropItem(new ItemStack(GCBlocks.oxygenPipe), 0.0F);
                 break;
             default:
-            	if (ConfigManagerCore.challengeMode) this.dropItem(Items.pumpkin_seeds, 1);
+            	if (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) this.dropItem(Items.pumpkin_seeds, 1);
                 break;
         }
     }
@@ -160,7 +160,7 @@ public class EntityEvolvedSkeleton extends EntitySkeleton implements IEntityBrea
         }
         
         //Drop lapis as semi-rare drop if player hit and if dropping bones
-        if (p_70628_1_ && ConfigManagerCore.challengeMode && j > 0 && this.rand.nextInt(12) == 0)
+        if (p_70628_1_ && (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) && j > 0 && this.rand.nextInt(12) == 0)
         	this.entityDropItem(new ItemStack(Items.dye, 1, 4), 0.0F);
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedSpider.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedSpider.java
@@ -129,7 +129,7 @@ public class EntityEvolvedSpider extends EntitySpider implements IEntityBreathab
                 this.dropItem(GCItems.oxygenConcentrator, 1);
                 break;
             default:
-            	if (ConfigManagerCore.challengeMode) this.dropItem(Items.nether_wart, 1);
+            	if (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) this.dropItem(Items.nether_wart, 1);
             	break;
         }
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedZombie.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedZombie.java
@@ -122,7 +122,7 @@ public class EntityEvolvedZombie extends EntityZombie implements IEntityBreathab
             case 13:
             case 14:
             case 15:
-            	if (ConfigManagerCore.challengeMode) this.dropItem(Items.melon_seeds, 1);
+            	if (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) this.dropItem(Items.melon_seeds, 1);
             	break;
         }
     }
@@ -149,7 +149,7 @@ public class EntityEvolvedZombie extends EntityZombie implements IEntityBreathab
         }
         
         //Drop copper ingot as semi-rare drop if player hit and if dropping rotten flesh (50% chance)
-        if (p_70628_1_ && ConfigManagerCore.challengeMode && j > 0 && this.rand.nextInt(6) == 0)
+        if (p_70628_1_ && (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) && j > 0 && this.rand.nextInt(6) == 0)
         	this.entityDropItem(new ItemStack(GCItems.basicItem, 1, 3), 0.0F);
     }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
@@ -1048,7 +1048,7 @@ public class GCPlayerHandler
         //This will speed things up a little
         final GCPlayerStats GCPlayer = GCPlayerStats.get(player);
 
-        if (ConfigManagerCore.challengeMode && GCPlayer.unlockedSchematics.size() == 0)
+        if ((ConfigManagerCore.challengeMode || ConfigManagerCore.challengeSpawnHandling) && GCPlayer.unlockedSchematics.size() == 0)
         {
         	if (GCPlayer.startDimension.length() > 0)
         		GCPlayer.startDimension = "";

--- a/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
@@ -284,7 +284,7 @@ public class EventHandlerGC
             {
                 if (!(entityLiving instanceof EntityPlayer) && (!(entityLiving instanceof IEntityBreathable) || !((IEntityBreathable) entityLiving).canBreath()) && !((IGalacticraftWorldProvider)entityLiving.worldObj.provider).hasBreathableAtmosphere())
                 {
-                    if (ConfigManagerCore.challengeMode && entityLiving instanceof EntityEnderman)
+                    if ((ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) && entityLiving instanceof EntityEnderman)
                     {
                     	return;
                     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
@@ -40,6 +40,10 @@ public class ConfigManagerCore
     public static boolean hardMode;
     public static boolean quickMode;
 	public static boolean challengeMode;
+	public static boolean challengeRecipes;
+	public static boolean challengeMobDropsAndSpawning;
+	public static boolean challengeSpawnHandling;
+	public static boolean challengeAsteroidPopulation;
     public static boolean disableRocketsToOverworld;
     public static boolean disableSpaceStationCreation;
     public static boolean spaceStationsRequirePermission;
@@ -465,6 +469,32 @@ public class ConfigManagerCore
             challengeMode = prop.getBoolean(false);
             if (!GalacticraftCore.isPlanetsLoaded) challengeMode = false;
             propOrder.add(prop.getName());
+            
+            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Adventure Game Mode Recipes", false);
+            prop.comment = "Set this to true to just enable the compressor recipes from Adventure Mode (regardless of whether the game mode is enabled).";
+            prop.setLanguageKey("gc.configgui.asteroidsRecipes");
+            challengeRecipes = prop.getBoolean(false);
+            propOrder.add(prop.getName());
+            
+            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Adventure Game Mode Mob Drops and Spawning", false);
+            prop.comment = "Set this to true to just enable the mob drops and mob spawning additions from Adventure Mode (regardless of whether the game mode is enabled).";
+            prop.setLanguageKey("gc.configgui.asteroidsMobDropsAndSpawning");
+            challengeMobDropsAndSpawning = prop.getBoolean(false);
+            propOrder.add(prop.getName());
+            
+            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Adventure Game Mode Spawn Handling", false);
+            prop.comment = "Set this to true to just enable players spawning in entry pods in the asteroids dimension like they would in Adventure Mode (regardless of whether the game mode is enabled, but only effective if Galacticraft Planets is installed).";
+            prop.setLanguageKey("gc.configgui.asteroidsSpawnHandling");
+            challengeSpawnHandling = prop.getBoolean(false);
+            if (!GalacticraftCore.isPlanetsLoaded) challengeSpawnHandling = false;
+            propOrder.add(prop.getName());
+            
+            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Adventure Game Mode Asteroid Population", false);
+            prop.comment = "Set this to true to just enable trees being placed in all hollow asteroids in the asteroids dimension like they would in Adventure Mode (regardless of whether the game mode is enabled, but only effective if Galacticraft Planets is installed).";
+            prop.setLanguageKey("gc.configgui.asteroidsAsteroidPopulation");
+            challengeAsteroidPopulation = prop.getBoolean(false);
+            if (!GalacticraftCore.isPlanetsLoaded) challengeAsteroidPopulation = false;
+            propOrder.add(prop.getName());
 
             prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Enable Sealed edge checks", true);
             prop.comment = "If this is enabled, areas sealed by Oxygen Sealers will run a seal check when the player breaks or places a block (or on block updates).  This should be enabled for a 100% accurate sealed status, but can be disabled on servers for performance reasons.";
@@ -754,6 +784,7 @@ public class ConfigManagerCore
     	returnList.add(ConfigManagerCore.suffocationCooldown);
     	returnList.add(ConfigManagerCore.rocketFuelFactor);
     	returnList.add(ConfigManagerCore.otherModsSilicon);
+    	returnList.add(ConfigManagerCore.challengeRecipes);
     	EnergyConfigHandler.serverConfigOverride(returnList);
     	
     	returnList.add(ConfigManagerCore.detectableIDs.clone());  	
@@ -775,6 +806,7 @@ public class ConfigManagerCore
     	ConfigManagerCore.suffocationCooldown = (Integer) configs.get(3);
     	ConfigManagerCore.rocketFuelFactor = (Integer) configs.get(4);
     	ConfigManagerCore.otherModsSilicon = (String) configs.get(5);
+    	ConfigManagerCore.challengeRecipes = (Boolean) configs.get(6);
     	
     	EnergyConfigHandler.setConfigOverride((Float) configs.get(6), (Float) configs.get(7), (Float) configs.get(8), (Float) configs.get(9), (Integer) configs.get(10));
     	

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -1242,7 +1242,7 @@ public class WorldUtil
 
     public static WorldServer getStartWorld(WorldServer worldOld)
     {
-        if (ConfigManagerCore.challengeMode)
+        if (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeSpawnHandling)
         {
         	WorldProvider wp = WorldUtil.getProviderForNameServer("planet.asteroids");
         	WorldServer worldNew = (wp == null) ? null : (WorldServer) wp.worldObj;

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/world/gen/ChunkProviderAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/world/gen/ChunkProviderAsteroids.java
@@ -689,7 +689,7 @@ public class ChunkProviderAsteroids extends ChunkProviderGenerate
                 int asteroidSize = asteroidIndex.asteroidSizeArray;
                 boolean treesdone = false;
                 
-                if(ConfigManagerCore.challengeMode || rand.nextInt(ChunkProviderAsteroids.TREE_CHANCE) == 0)
+                if(ConfigManagerCore.challengeMode || ConfigManagerCore.challengeAsteroidPopulation || rand.nextInt(ChunkProviderAsteroids.TREE_CHANCE) == 0)
                 {
                 	int treeType = rand.nextInt(3);
                 	if (treeType == 1) treeType = 0;
@@ -881,7 +881,7 @@ public class ChunkProviderAsteroids extends ChunkProviderGenerate
             monsters.add(new SpawnListEntry(EntityEvolvedSpider.class, 2000, 1, 2));
             monsters.add(new SpawnListEntry(EntityEvolvedSkeleton.class, 1500, 1, 1));
             monsters.add(new SpawnListEntry(EntityEvolvedCreeper.class, 2000, 1, 1));
-            if (ConfigManagerCore.challengeMode) monsters.add(new SpawnListEntry(EntityEnderman.class, 250, 1, 1));
+            if (ConfigManagerCore.challengeMode || ConfigManagerCore.challengeMobDropsAndSpawning) monsters.add(new SpawnListEntry(EntityEnderman.class, 250, 1, 1));
             return monsters;
         }
         else


### PR DESCRIPTION
This adds separate settings to enable the compressor recipes, mob drops/spawns, spawn handling, and asteroid population from the asteroid challenge mode.

For example, this would allow someone to use their own spawn control system to customize players' starting positions and materials, but keep the added recipes and mob drops and spawns. One could also use these settings to keep the challenge mode player spawning and asteroid population, but set up their own mob drops and recipes.

I placed all the new config settings into the API's config access, since I didn't know if other mod authors might one day find it useful to know what individual parts of the challenge mode are enabled. I only added the challenge recipes setting to the server config override, since this was the only individual part I could think of where the client's setting would need to be synchronized with the server's. Please let me know and/or change my code if I made the wrong decisions here.