### PR TITLE
Bubble Distributor doesn't "hasEnoughEnergyToRun"

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenDistributor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenDistributor.java
@@ -192,7 +192,7 @@ public class TileEntityOxygenDistributor extends TileEntityOxygen implements IIn
 
         if (!this.worldObj.isRemote)
         {
-            if (this.getEnergyStoredGC() > 0.0F && this.storedOxygen > this.oxygenPerTick)
+            if (this.getEnergyStoredGC() > 0.0F && this.hasEnoughEnergyToRun && this.storedOxygen > this.oxygenPerTick)
             {
                 this.bubbleSize += 0.01F;
             }


### PR DESCRIPTION
Found this while trying to re-enable redstone control in my own fork (since applying redstone makes this false and the bubble distrib didn't care.) Not huge but just something that seemed forgotten.