### PR TITLE
Add Space Chickens

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -194,6 +194,7 @@ public class GalacticraftCore
         GalacticraftCore.moonMoon.addMobInfo(new SpawnListEntry(EntityEvolvedSkeleton.class, 8, 2, 3));
         GalacticraftCore.moonMoon.addMobInfo(new SpawnListEntry(EntityEvolvedCreeper.class, 8, 2, 3));
         GalacticraftCore.moonMoon.addMobInfo(new SpawnListEntry(EntityEvolvedEnderman.class, 10, 1, 4));
+		GalacticraftCore.moonMoon.addMobInfo(new SpawnListEntry(EntitySpaceChicken.class, 8, 2, 3));
         GalacticraftCore.moonMoon.addChecklistKeys("equipOxygenSuit");
 
         //Satellites must always have a WorldProvider implementing IOrbitDimension
@@ -528,6 +529,7 @@ public class GalacticraftCore
         GCCoreUtil.registerGalacticraftCreature(EntityAlienVillager.class, "alien_villager", ColorUtil.to32BitColor(255, 103, 145, 181), 12422002);
         GCCoreUtil.registerGalacticraftCreature(EntityEvolvedEnderman.class, "evolved_enderman", 1447446, 0);
         GCCoreUtil.registerGalacticraftCreature(EntityEvolvedWitch.class, "evolved_witch", 3407872, 5349438);
+		GCCoreUtil.registerGalacticraftNonMobEntity(EntitySpaceChicken.class, "space_chicken", 80, 3, true);//register SpaceChicken
     }
 
     private void registerOtherEntities()

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelSpaceChicken.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelSpaceChicken.java
@@ -1,0 +1,3 @@
+package micdoodle8.mods.galacticraft.core.client.model;
+
+//How do models work? I don't know how so you will have to add that

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderSpaceChicken.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderSpaceChicken.java
@@ -1,0 +1,38 @@
+package micdoodle8.mods.galacticraft.core.client.render.entities;
+import java.util.Random;
+
+import micdoodle8.mods.galacticraft.core.Constants;
+import micdoodle8.mods.galacticraft.core.client.model.ModelSpaceChicken;
+import micdoodle8.mods.galacticraft.core.entities.EntitySpaceChicken;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.renderer.entity.RenderLiving;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class RenderSpaceChicken extends RenderLiving<EntityEvolvedEnderman>
+{
+    private static final ResourceLocation chickenTexture = new ResourceLocation(Constants.ASSET_PREFIX, "textures/model/space_chicken.png");
+    private ModelSpaceChicken chickenModel;
+    private Random rnd = new Random();
+
+    public RenderSpaceChicken(RenderManager manager)
+    {
+        super(manager, new ModelSpaceChicken(), 0.5F);
+        this.chickenModel = (ModelSpaceChicken)super.mainModel;
+    }
+
+    @Override
+    protected ResourceLocation getEntityTexture(EntitySpaceChicken entity)
+    {
+        return RenderSpaceChicken.chickenTexture;
+    }
+
+    @Override
+    public void doRender(EntitySpaceChicken entity, double x, double y, double z, float entityYaw, float partialTicks)
+    {
+        super.doRender(entity, x, y, z, entityYaw, partialTicks);
+    }
+} 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntitySpaceChicken.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntitySpaceChicken.java
@@ -1,0 +1,53 @@
+package micdoodle8.mods.galacticraft.core.entities;
+
+import micdoodle8.mods.galacticraft.api.entity.IEntityBreathable;
+import micdoodle8.mods.galacticraft.core.GCItems;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.passive.EntityChicken;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class EntitySpaceChicken extends EntityChicken implements IEntityBreathable
+{
+    public EntitySpaceChicken(World world)
+    {
+        super(world);
+    }
+
+    @Override
+    public boolean canBreath()
+    {
+        return true;
+    }
+
+    @Override
+    protected void addRandomDrop()
+    {
+        switch (this.rand.nextInt(10))
+        {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+            this.dropItem(Items.feather, 1);
+            break;
+        case 6:
+            //Oxygen tank half empty or less
+            this.entityDropItem(new ItemStack(GCItems.oxTankMedium, 1, 901 + this.rand.nextInt(900)), 0.0F);
+            break;
+        case 7:
+        case 8:
+            this.dropItem(Items.ender_eye, 1);
+            break;
+        case 9:
+            this.dropItem(GCItems.oxygenConcentrator, 1);
+            break;
+        case 10:
+            this.dropItem(GCItems.oxMask, 1);
+            break;
+        }
+    }
+} 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
@@ -431,6 +431,7 @@ public class ClientProxyCore extends CommonProxyCore
         RenderingRegistry.registerEntityRenderingHandler(EntityMeteorChunk.class, (RenderManager manager) -> new RenderMeteorChunk(manager));
         RenderingRegistry.registerEntityRenderingHandler(EntityHangingSchematic.class, (RenderManager manager) -> new RenderSchematic(manager));
         RenderingRegistry.registerEntityRenderingHandler(EntityEvolvedEnderman.class, (RenderManager manager) -> new RenderEvolvedEnderman(manager));
+		RenderingRegistry.registerEntityRendeingHandler(EntitySpaceChicken.class, (RenderManager manager) -> new RenderSpaceChicken(manager));
         RenderingRegistry.registerEntityRenderingHandler(EntityEvolvedWitch.class, (RenderManager manager) -> new RenderEvolvedWitch(manager));
     }
 

--- a/src/main/resources/assets/galacticraftcore/lang/en_US.lang
+++ b/src/main/resources/assets/galacticraftcore/lang/en_US.lang
@@ -45,6 +45,7 @@ entity.evolved_spider.name=Evolved Spider
 entity.evolved_zombie.name=Evolved Zombie
 entity.evolved_enderman.name=Evolved Enderman
 entity.evolved_witch.name=Evolved Witch
+entity.space_chicken.name=Space Chicken
 entity.flag.name=Flag
 entity.gcflag.name=Flag
 entity.gravity_arrow.name=Arrow


### PR DESCRIPTION
I (tried) to add space chickens to Galacticraft that spawn on the moon. Not sure if they work, as I haven't tested it. The reason for that is that I do not know how to make models and so if I try to load it it crashes from having no model. If you guys can add a model, it should work fine. Also sorry for conflicting with your code style, but in the entity registration in GalacticraftCore.java, I couldn't figure out how the last 2 arguments in registerGalacticraftCreature(back and fore) worked so I just used registerGalacticraftNonMobEntity. This means it has no spawn egg. Sorry about that. I just wanted to contribute to my favorite mod.