### PR TITLE
Fix Sponge issue for Spider Queen Boss not dropping a key

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/venus/entities/EntitySpiderQueen.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/venus/entities/EntitySpiderQueen.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.*;
 import net.minecraft.entity.ai.*;
 import net.minecraft.entity.boss.IBossDisplayData;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -411,6 +412,23 @@ public class EntitySpiderQueen extends EntityBossBase implements IEntityBreathab
         return 3;
     }
 
+    @Override
+    public EntityItem entityDropItem(ItemStack par1ItemStack, float par2)
+    {
+        final EntityItem entityitem = new EntityItem(this.worldObj, this.posX, this.posY + par2, this.posZ, par1ItemStack);
+        entityitem.motionY = -2.0D;
+        entityitem.setDefaultPickupDelay();
+        if (this.captureDrops)
+        {
+            this.capturedDrops.add(entityitem);
+        }
+        else
+        {
+            this.worldObj.spawnEntityInWorld(entityitem);
+        }
+        return entityitem;
+    }
+    
     @Override
     public void dropKey()
     {


### PR DESCRIPTION
I found a sponge issue with my addon and adding this to my entity class fixes it, i also saw that this is the only boss that didn't have this function in it in Galacticraft so this should fix this issue for you :D 
