### PR TITLE
Return SUCCESS in ItemTier1Rocket after consuming item

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemTier1Rocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemTier1Rocket.java
@@ -137,7 +137,7 @@ public class ItemTier1Rocket extends Item implements IHoldableItem, ISortableIte
                 return EnumActionResult.FAIL;
             }
         }
-        return EnumActionResult.PASS;
+        return EnumActionResult.SUCCESS;
     }
 
     @Override


### PR DESCRIPTION
`ItemTier1Rocket` should return `SUCCESS` (just like `ItemTier2Rocket` and `ItemTier3Rocket` already do) when it consumes an item.

Normally, this doesn't cause any issues but SpongeForge is a bit more strict about the return values and will restore the item unless the handler returned `SUCCESS`, which makes it possible to place infinite rockets.

Might be related to issue 1 of #2953 if it only happened with tier 1 rockets.