### PR TITLE
Override getUpdateTag() in TileEntityScreen to send the correct data to the client (for #3032).

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityScreen.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityScreen.java
@@ -414,6 +414,14 @@ public class TileEntityScreen extends TileEntityAdvanced implements ITileClientU
         return nbt;
     }
 
+    @Override
+    public NBTTagCompound getUpdateTag()
+    {
+        NBTTagCompound tag = new NBTTagCompound();
+        this.writeToNBT(new NBTTagCompound());
+        return tag;
+    }
+
     public void checkScreenSize()
     {
         this.log("Checking screen size");


### PR DESCRIPTION
Sorry I couldn't give an update on the master branch, I wasn't able to get it to run properly. Not sure what the equivalent is in master, but it will need to be tweaked for other Minecraft versions. Looks like older versions had getDescriptionPacket?