### PR TITLE
Fixed can't take out item from Cargo Loader. Fixes #3035

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/world/gen/base/BaseRoom.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/world/gen/base/BaseRoom.java
@@ -528,7 +528,6 @@ public class BaseRoom extends SizedPiece
             else if (tile instanceof TileEntityCargoLoader)
             {
                 TileEntityCargoLoader loader = (TileEntityCargoLoader) tile;
-                loader.locked = true;
                 //Looks like the food supplies have gone off!
                 loader.addCargo(new ItemStack(Items.poisonous_potato, 64, 0), true);
                 loader.addCargo(new ItemStack(Items.poisonous_potato, 64, 0), true);


### PR DESCRIPTION
Please tell me if this is intended behavior. But I think it doesn't make sense.