### PR TITLE
Add ability for addons to have their Dungeon loot added to Mars Boss

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityCreeperBoss.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityCreeperBoss.java
@@ -244,13 +244,19 @@ public class EntityCreeperBoss extends EntityBossBase implements IEntityBreathab
             {
                 for (ISchematicPage page : stats.getUnlockedSchematics())
                 {
-                    if (page.getPageID() == ConfigManagerAsteroids.idSchematicRocketT3)
+                    // Check to see if player as the Astro Miner schematic, if so add all schematics to the mix
+                	if (page.getPageID() == ConfigManagerAsteroids.idSchematicRocketT3 + 1) // ID for Astro Miner Schematic Page
+                    {
+                        range = stackList.size();
+                        break;
+                    }
+                	else if (page.getPageID() == ConfigManagerAsteroids.idSchematicRocketT3)
                     {
                         range = 3;
                         break;
                     }
                 }
-                if (stats.getRocketItem() == AsteroidsItems.tier3Rocket)
+                if (stats.getRocketItem() == AsteroidsItems.tier3Rocket) // Is this really needed?
                 {
                     range = 3;
                 }


### PR DESCRIPTION
At the moment the Mars Dungeon Boss is hardcoded to only allow Galacticraft Tier 3 Rocket, Astro Miner & Cargo Rocket to be possible loot.

This change makes it so when the Astro Miner is obtained it will allow addon loot to be added, this way it still works the way it currently is but has a extra on the end for addons.

I've also added a comment to a line to if its even needed feel free to remove that comment if it is needed.