### PR TITLE
Correct description for maximumAstroMiners

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/ConfigManagerAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/ConfigManagerAsteroids.java
@@ -104,7 +104,7 @@ public class ConfigManagerAsteroids
             GalacticraftPlanets.finishProp(prop, Constants.CONFIG_CATEGORY_GENERAL);
 
             prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "maximumAstroMiners", 6);
-            prop.comment = "Maximum number of Astro Miners each player is allowed to have active (default 4).";
+            prop.comment = "Maximum number of Astro Miners each player is allowed to have active (default 6).";
             prop.setLanguageKey("gc.configgui.astro_miners_max");
             if (update)
             {


### PR DESCRIPTION
It seems that the default value [changed](https://github.com/micdoodle8/Galacticraft/commit/bb7a16562d28e3f185edaa200bc199242739463d#diff-15fc6195c29b4495451976190a2ba562l) since the config was added.