### PR TITLE
Added support for add-ons to have Sensor Glasses Armor Items

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/item/ISensorGlassesArmor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/item/ISensorGlassesArmor.java
@@ -1,0 +1,5 @@
+package micdoodle8.mods.galacticraft.api.item;
+
+public interface ISensorGlassesArmor {
+
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/overlay/OverlaySensorGlasses.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/overlay/OverlaySensorGlasses.java
@@ -1,9 +1,11 @@
 package micdoodle8.mods.galacticraft.core.client.gui.overlay;
 
+import java.util.Iterator;
+
+import micdoodle8.mods.galacticraft.api.item.ISensorGlassesArmor;
 import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStatsClient;
-import micdoodle8.mods.galacticraft.core.items.ItemSensorGlasses;
 import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
 import micdoodle8.mods.galacticraft.core.util.ClientUtil;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
@@ -24,8 +26,6 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.lwjgl.opengl.GL11;
-
-import java.util.Iterator;
 
 @SideOnly(Side.CLIENT)
 public class OverlaySensorGlasses extends Overlay
@@ -151,6 +151,6 @@ public class OverlaySensorGlasses extends Overlay
     public static boolean overrideMobTexture()
     {
         EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-        return (player != null && player.inventory.armorItemInSlot(3) != null && player.inventory.armorItemInSlot(3).getItem() instanceof ItemSensorGlasses);
+        return (player != null && player.inventory.armorItemInSlot(3) != null && player.inventory.armorItemInSlot(3).getItem() instanceof ISensorGlassesArmor);
     }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemSensorGlasses.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemSensorGlasses.java
@@ -1,5 +1,6 @@
 package micdoodle8.mods.galacticraft.core.items;
 
+import micdoodle8.mods.galacticraft.api.item.ISensorGlassesArmor;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.GCItems;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
@@ -16,7 +17,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemSensorGlasses extends ItemArmor implements ISortableItem
+public class ItemSensorGlasses extends ItemArmor implements ISortableItem, ISensorGlassesArmor
 {
     public ItemSensorGlasses(String assetName)
     {


### PR DESCRIPTION
Hello,

So please let me explain why im making this change. 

In my addon i have Pressure and Radiation System that requires the player to wear a space suit at all times. So im working on a module system for players to install different features to there space suit so players are not missing out on features that require use of armor slots like the sensor glasses.

Making this change i've done allows any armour anyone makes be able to work as sensor glasses as well as the Sensor Glasses item.

Basically i really need this :D 

I've tested the Sensor Glasses item works fine still with the added ability of allowing my feature in my addon to work too :D