### PR TITLE
Change  "[1.12] Stop using deprecated logging"

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/GCLog.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/GCLog.java
@@ -1,31 +1,34 @@
 package micdoodle8.mods.galacticraft.core.util;
 
 import micdoodle8.mods.galacticraft.core.Constants;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
 
 public class GCLog
 {
+    
+    private static Logger log;
+    
     public static void info(String message)
     {
-        FMLRelaunchLog.log(Constants.MOD_NAME_SIMPLE, Level.INFO, message);
+        log.info(Constants.MOD_NAME_SIMPLE + ": "+ message);
+        
     }
 
     public static void severe(String message)
     {
-        FMLRelaunchLog.log(Constants.MOD_NAME_SIMPLE, Level.ERROR, message);
+        log.error(Constants.MOD_NAME_SIMPLE + ": " + message);
     }
 
     public static void debug(String message)
     {
         if (ConfigManagerCore.enableDebug)
         {
-            FMLRelaunchLog.log(Constants.MOD_NAME_SIMPLE, Level.INFO, "Debug: " + message);
+            log.debug(Constants.MOD_NAME_SIMPLE + ": "+ message);
         }
     }
 
-	public static void exception(Exception e)
-	{
-		FMLRelaunchLog.log(Constants.MOD_NAME_SIMPLE, Level.ERROR, e.getMessage());
-	}
+    public static void exception(Exception e)
+    {
+        log.catching(e);
+    }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/GCLog.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/GCLog.java
@@ -1,29 +1,31 @@
 package micdoodle8.mods.galacticraft.core.util;
 
 import micdoodle8.mods.galacticraft.core.Constants;
+
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class GCLog
 {
     
-    private static Logger log;
+    private static Logger log = LogManager.getFormatterLogger(Constants.MOD_NAME_SIMPLE);
     
     public static void info(String message)
     {
-        log.info(Constants.MOD_NAME_SIMPLE + ": "+ message);
+        log.info(message);
         
     }
 
     public static void severe(String message)
     {
-        log.error(Constants.MOD_NAME_SIMPLE + ": " + message);
+        log.error(message);
     }
 
     public static void debug(String message)
     {
         if (ConfigManagerCore.enableDebug)
         {
-            log.debug(Constants.MOD_NAME_SIMPLE + ": "+ message);
+            log.debug(message);
         }
     }
 


### PR DESCRIPTION
Sorry @radfast 
This one fixes formatting. Now "[Galacticraft]:" not "Galacticraft:"
Saves line space though.
Formatting of #3377 😞 