### PR TITLE
Fixed possible dungeon crash issue

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/dungeon/RoomBoss.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/dungeon/RoomBoss.java
@@ -139,9 +139,12 @@ public class RoomBoss extends SizedPiece
     {
         super.writeStructureToNBT(tagCompound);
 
-        tagCompound.setInteger("chestX", this.chestPos.getX());
-        tagCompound.setInteger("chestY", this.chestPos.getY());
-        tagCompound.setInteger("chestZ", this.chestPos.getZ());
+        if(this.chestPos != null)
+        {
+            tagCompound.setInteger("chestX", this.chestPos.getX());
+            tagCompound.setInteger("chestY", this.chestPos.getY());
+            tagCompound.setInteger("chestZ", this.chestPos.getZ());
+        }
     }
 
     @Override


### PR DESCRIPTION
Ok so in https://github.com/DarkPacks/SevTech-Ages/issues/2175 issue someone reported a issue where it would crash on a ExtraPlanets dungeon. I debugged this back to just a bad seed and just needs a simple null point checker to stop the crash and allow the dungeon just be not usable

See comments over at the issue for a screenshot/more info on this 