### PR TITLE
Change canCreateStations variable to public

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/screen/GuiCelestialSelection.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/screen/GuiCelestialSelection.java
@@ -101,7 +101,7 @@ public class GuiCelestialSelection extends GuiScreen
     protected int lastMovePosX = -1;
     protected int lastMovePosY = -1;
     protected boolean errorLogged = false;
-    protected boolean canCreateStations = false;
+    public boolean canCreateStations = false;
     List<CelestialBody> bodiesToRender = Lists.newArrayList();
 
     // String colours


### PR DESCRIPTION
Only needed 1.10+ since it only exists above 1.8 in the constructor for GuiCelestialSelection

Needed to solve my issue of https://github.com/MJRLegends/ExtraPlanets/issues/300 since i need to get the value from GuiCelestialSelection that was sent and parse it to my custom screen. (i already do this for List<CelestialBody> possibleBodies since that one is already public not protected)

Any more questions please let me know