### PR TITLE
Fix cone render tier 3 rocket

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderTier3Rocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderTier3Rocket.java
@@ -120,10 +120,10 @@ public class RenderTier3Rocket extends Render<EntityTier3Rocket>
         GlStateManager.disableTexture2D();
 
         Vector3 teamColor = ClientUtil.updateTeamColor(FMLClientHandler.instance().getClient().thePlayer.getName(), true);
+        ClientUtil.drawBakedModel(coneModel);
         if (teamColor != null)
         {
             int color = ColorUtil.to32BitColor(255, (int)(teamColor.floatZ() * 255), (int)(teamColor.floatY() * 255), (int)(teamColor.floatX() * 255));
-            ClientUtil.drawBakedModelColored(coneModel, color);
         }
         else
         {


### PR DESCRIPTION
Now the cone is correctly displayed. Result:
![2018-06-01_18 05 39](https://user-images.githubusercontent.com/33905242/40848654-7b294a94-65c8-11e8-9acf-58759cb0fd52.png)
