### PR TITLE
Corrected ItemStack null checks

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/CompressorRecipes.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/CompressorRecipes.java
@@ -248,7 +248,7 @@ public class CompressorRecipes
             for (IRecipe recipe : result)
             {
                 ItemStack output = recipe.getRecipeOutput();
-                if (output == null) continue;
+                if (output.isEmpty()) continue;
                 if (output.getItemDamage() == 9 && output.getItem() == GCItems.basicItem && recipe instanceof ShapelessOreRecipeGC)
                 {
                     if (((ShapelessOreRecipeGC)recipe).matches(steelRecipeGC))
@@ -275,7 +275,7 @@ public class CompressorRecipes
             for (IRecipe recipe : CompressorRecipes.recipes)
             {
                 ItemStack output = recipe.getRecipeOutput();
-                if (output == null) continue;
+                if (output.isEmpty()) continue;
                 if (output.getItemDamage() == 9 && output.getItem() == GCItems.basicItem && recipe instanceof ShapelessOreRecipeGC)
                 {
                     if (((ShapelessOreRecipeGC)recipe).matches(steelRecipeGC))

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/SpaceStationRecipe.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/SpaceStationRecipe.java
@@ -78,7 +78,7 @@ public class SpaceStationRecipe
             {
                 final ItemStack slot = player.inventory.getStackInSlot(x);
 
-                if (slot != null)
+                if (!slot.isEmpty())
                 {
                     if (next instanceof ItemStack)
                     {
@@ -133,7 +133,7 @@ public class SpaceStationRecipe
             {
                 final ItemStack slot = player.inventory.getStackInSlot(x);
 
-                if (slot != null)
+                if (!slot.isEmpty())
                 {
                     final int amountRemaining = amountRequired - amountRemoved;
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockAdvancedTile.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockAdvancedTile.java
@@ -61,7 +61,7 @@ public abstract class BlockAdvancedTile extends BlockAdvanced implements ITileEn
                 {
                     ItemStack var7 = inventory.getStackInSlot(var6);
 
-                    if (var7 != null && !var7.isEmpty())
+                    if (!var7.isEmpty())
                     {
                         float var8 = syncRandom.nextFloat() * 0.8F + 0.1F;
                         float var9 = syncRandom.nextFloat() * 0.8F + 0.1F;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockFallenMeteor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockFallenMeteor.java
@@ -259,7 +259,7 @@ public class BlockFallenMeteor extends Block implements ITileEntityProvider, ISh
     {
         ItemStack stack = player.inventory.getCurrentItem();
         String tool = block.getHarvestTool(state);
-        if (stack == null || tool == null)
+        if (stack.isEmpty() || tool == null)
         {
             return player.canHarvestBlock(state) ? 1 : 0;
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockFluidPipe.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockFluidPipe.java
@@ -239,7 +239,7 @@ public class BlockFluidPipe extends BlockTransmitter implements ITileEntityProvi
         {
             final ItemStack stack = playerIn.inventory.getCurrentItem();
 
-            if (stack != null)
+            if (!stack.isEmpty())
             {
                 if (stack.getItem() instanceof ItemDye)
                 {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockTelemetry.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockTelemetry.java
@@ -116,7 +116,7 @@ public class BlockTelemetry extends BlockAdvancedTile implements IShiftDescripti
             {
                 ItemStack held = entityPlayer.inventory.getCurrentItem();
                 //Look for Frequency Module
-                if (held != null && held.getItem() == GCItems.basicItem && held.getItemDamage() == 19)
+                if (!held.isEmpty() && held.getItem() == GCItems.basicItem && held.getItemDamage() == 19)
                 {
                     NBTTagCompound fmData = held.getTagCompound();
                     if (fmData != null && fmData.hasKey("linkedUUIDMost") && fmData.hasKey("linkedUUIDLeast"))

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelBipedGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelBipedGC.java
@@ -31,7 +31,7 @@ public class ModelBipedGC
         final ItemStack currentItemStack = player.inventory.getCurrentItem();
         final float floatPI = 3.1415927F;
 
-        if (!par7Entity.onGround && par7Entity.world.provider instanceof IGalacticraftWorldProvider && par7Entity.getRidingEntity() == null && !(currentItemStack != null && currentItemStack.getItem() instanceof IHoldableItem))
+        if (!par7Entity.onGround && par7Entity.world.provider instanceof IGalacticraftWorldProvider && par7Entity.getRidingEntity() == null && !(!currentItemStack.isEmpty() && currentItemStack.getItem() instanceof IHoldableItem))
         {
             float speedModifier = 0.1162F * 2;
 
@@ -66,7 +66,7 @@ public class ModelBipedGC
         for (EnumHand hand : EnumHand.values())
         {
             ItemStack item = player.getHeldItem(hand);
-            if (item != null && item.getItem() instanceof IHoldableItem)
+            if (!item.isEmpty() && item.getItem() instanceof IHoldableItem)
             {
                 heldItemStack = item;
             }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/layer/LayerHeldItemEvolvedSkeletonBoss.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/layer/LayerHeldItemEvolvedSkeletonBoss.java
@@ -42,7 +42,7 @@ public class LayerHeldItemEvolvedSkeletonBoss implements LayerRenderer<EntitySke
     {
         ItemStack bow = new ItemStack(Items.BOW);
 
-        if (bow != null)
+        if (!bow.isEmpty())
         {
             GlStateManager.pushMatrix();
             ((ModelEvolvedSkeletonBoss)this.renderer.getMainModel()).postRenderArm(0.0625F, type);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/layer/LayerHeldItemEvolvedWitch.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/layer/LayerHeldItemEvolvedWitch.java
@@ -28,7 +28,7 @@ public class LayerHeldItemEvolvedWitch implements LayerRenderer<EntityEvolvedWit
     {
         ItemStack itemstack = entity.getHeldItemMainhand();
 
-        if (itemstack != null)
+        if (!itemstack.isEmpty())
         {
             GlStateManager.color(1.0F, 1.0F, 1.0F);
             GlStateManager.pushMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/layer/LayerHeldItemGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/layer/LayerHeldItemGC.java
@@ -35,7 +35,7 @@ public class LayerHeldItemGC implements LayerRenderer<AbstractClientPlayer>
         ItemStack itemstack = flag ? player.getHeldItemOffhand() : player.getHeldItemMainhand();
         ItemStack itemstack1 = flag ? player.getHeldItemMainhand() : player.getHeldItemOffhand();
 
-        if (itemstack != null || itemstack1 != null)
+        if (!itemstack.isEmpty() || !itemstack1.isEmpty())
         {
             GlStateManager.pushMatrix();
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityAlienVillager.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityAlienVillager.java
@@ -171,7 +171,7 @@ public class EntityAlienVillager extends EntityAgeable implements IMerchant, INp
     public boolean processInteract(EntityPlayer player, EnumHand hand)
     {
         ItemStack itemstack = player.inventory.getCurrentItem();
-        boolean flag = itemstack != null && itemstack.getItem() == Items.SPAWN_EGG;
+        boolean flag = !itemstack.isEmpty() && itemstack.getItem() == Items.SPAWN_EGG;
 
         if (!flag && this.isEntityAlive() && !this.isTrading() && !this.isChild() && !player.isSneaking())
         {
@@ -225,7 +225,7 @@ public class EntityAlienVillager extends EntityAgeable implements IMerchant, INp
         {
             ItemStack itemstack = this.villagerInventory.getStackInSlot(i);
 
-            if (itemstack != null)
+            if (!itemstack.isEmpty())
             {
                 nbttaglist.appendTag(itemstack.writeToNBT(new NBTTagCompound()));
             }
@@ -252,7 +252,7 @@ public class EntityAlienVillager extends EntityAgeable implements IMerchant, INp
         {
             ItemStack itemstack = new ItemStack(nbttaglist.getCompoundTagAt(i));
 
-            if (itemstack != null)
+            if (!itemstack.isEmpty())
             {
                 this.villagerInventory.addItem(itemstack);
             }
@@ -431,7 +431,7 @@ public class EntityAlienVillager extends EntityAgeable implements IMerchant, INp
         {
             this.livingSoundTime = -this.getTalkInterval();
 
-            if (stack != null)
+            if (!stack.isEmpty())
             {
                 this.playSound(SoundEvents.ENTITY_VILLAGER_YES, this.getSoundVolume(), this.getSoundPitch());
             }
@@ -625,7 +625,7 @@ public class EntityAlienVillager extends EntityAgeable implements IMerchant, INp
         {
             ItemStack itemstack = this.villagerInventory.getStackInSlot(i);
 
-            if (itemstack != null)
+            if (itemstack.isEmpty())
             {
                 if (itemstack.getItem() == Items.BREAD && itemstack.getCount() >= 3 * multiplier || itemstack.getItem() == Items.POTATO && itemstack.getCount() >= 12 * multiplier || itemstack.getItem() == Items.CARROT && itemstack.getCount() >= 12 * multiplier)
                 {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityBuggy.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityBuggy.java
@@ -678,7 +678,7 @@ public class EntityBuggy extends Entity implements IInventoryDefaults, IPacketRe
         {
             ItemStack stackAt = this.stacks.get(count);
 
-            if (stackAt != null && stackAt.getItem() == stack.getItem() && stackAt.getItemDamage() == stack.getItemDamage() && stackAt.getCount() < stackAt.getMaxStackSize())
+            if (!stackAt.isEmpty() && stackAt.getItem() == stack.getItem() && stackAt.getItemDamage() == stack.getItemDamage() && stackAt.getCount() < stackAt.getMaxStackSize())
             {
                 if (stackAt.getCount() + stack.getCount() <= stackAt.getMaxStackSize())
                 {
@@ -718,7 +718,7 @@ public class EntityBuggy extends Entity implements IInventoryDefaults, IPacketRe
         {
             ItemStack stackAt = this.stacks.get(count);
 
-            if (stackAt == null)
+            if (stackAt.isEmpty())
             {
                 if (doAdd)
                 {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCEntityOtherPlayerMP.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCEntityOtherPlayerMP.java
@@ -68,7 +68,7 @@ public class GCEntityOtherPlayerMP extends EntityOtherPlayerMP
     {
         if (EventHandlerClient.sneakRenderOverride && !(this.world.provider instanceof IZeroGDimension))
         {
-            if (this.onGround && this.inventory.getCurrentItem() != null && this.inventory.getCurrentItem().getItem() instanceof IHoldableItem && !(this.getRidingEntity() instanceof ICameraZoomEntity))
+            if (this.onGround && !this.inventory.getCurrentItem().isEmpty() && this.inventory.getCurrentItem().getItem() instanceof IHoldableItem && !(this.getRidingEntity() instanceof ICameraZoomEntity))
             {
                 IHoldableItem holdableItem = (IHoldableItem) this.inventory.getCurrentItem().getItem();
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
@@ -1407,7 +1407,7 @@ public class GCPlayerHandler
             {
                 boolean doneDungeon = false;
                 ItemStack current = player.inventory.getCurrentItem();
-                if (current != null && current.getItem() == GCItems.dungeonFinder)
+                if (!current.isEmpty() && current.getItem() == GCItems.dungeonFinder)
                 {
                     this.sendDungeonDirectionPacket(player, stats);
                     doneDungeon = true;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
@@ -225,7 +225,7 @@ public class EventHandlerGC
         final ItemStack heldStack = event.getEntityPlayer().inventory.getCurrentItem();
         final TileEntity tileClicked = worldObj.getTileEntity(event.getPos());
 
-        if (heldStack != null)
+        if (!heldStack.isEmpty())
         {
             if (tileClicked != null && tileClicked instanceof IKeyable)
             {
@@ -293,7 +293,7 @@ public class EventHandlerGC
         final ItemStack heldStack = event.getEntityPlayer().inventory.getCurrentItem();
         final TileEntity tileClicked = worldObj.getTileEntity(event.getPos());
 
-        if (heldStack != null)
+        if (!heldStack.isEmpty())
         {
             if (tileClicked != null && tileClicked instanceof IKeyable)
             {
@@ -409,7 +409,7 @@ public class EventHandlerGC
     @SubscribeEvent
     public void onBucketFill(FillBucketEvent event)
     {
-        if (event.getEmptyBucket() == null || !(event.getEmptyBucket().getItem() instanceof ItemBucket))
+        if (event.getEmptyBucket().isEmpty() || !(event.getEmptyBucket().getItem() instanceof ItemBucket))
         {
             return;
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
@@ -811,7 +811,7 @@ public class PacketSimple extends PacketBase implements Packet<INetHandler>
                     {
                         ItemStack stack2 = stats.getExtendedInventory().getStackInSlot(4);
 
-                        if (stack2 != null && stack2.getItem() instanceof ItemParaChute || stats.getLaunchAttempts() > 0)
+                        if (!stack2.isEmpty() && stack2.getItem() instanceof ItemParaChute || stats.getLaunchAttempts() > 0)
                         {
                             ship.igniteCheckingCooldown();
                             stats.setLaunchAttempts(0);
@@ -1289,7 +1289,7 @@ public class PacketSimple extends PacketBase implements Packet<INetHandler>
             for (EnumHand enumhand : EnumHand.values())
             {
                 ItemStack stack = player.getHeldItem(enumhand);
-                if (stack != null && stack.getItem() == GCItems.prelaunchChecklist)
+                if (!stack.isEmpty() && stack.getItem() == GCItems.prelaunchChecklist)
                 {
                     NBTTagCompound tagCompound = stack.getTagCompound();
                     if (tagCompound == null)

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerClient.java
@@ -428,7 +428,7 @@ public class TickHandlerClient
                     }
                 }
 
-                if (player.inventory.armorItemInSlot(3) != null && player.inventory.armorItemInSlot(3).getItem() instanceof ItemSensorGlasses)
+                if (!player.inventory.armorItemInSlot(3).isEmpty() && player.inventory.armorItemInSlot(3).getItem() instanceof ItemSensorGlasses)
                 {
                     ClientProxyCore.valueableBlocks.clear();
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityCircuitFabricator.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityCircuitFabricator.java
@@ -200,7 +200,7 @@ public class TileEntityCircuitFabricator extends TileBaseElectricBlockWithInvent
     {
         if (slotID == 0)
         {
-            return itemStack != null && ItemElectricBase.isElectricItem(itemStack.getItem());
+            return !itemStack.isEmpty() && ItemElectricBase.isElectricItem(itemStack.getItem());
         }
 
         if (slotID > 5)

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityDeconstructor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityDeconstructor.java
@@ -600,7 +600,7 @@ public class TileEntityDeconstructor extends TileBaseElectricBlock implements II
     {
         if (slotID == 0)
         {
-            return itemStack != null && !itemStack.isEmpty() && ItemElectricBase.isElectricItem(itemStack.getItem());
+            return !itemStack.isEmpty() && ItemElectricBase.isElectricItem(itemStack.getItem());
         }
         
         return slotID == 1;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityElectricIngotCompressor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityElectricIngotCompressor.java
@@ -397,7 +397,7 @@ public class TileEntityElectricIngotCompressor extends TileBaseElectricBlock imp
     {
         if (slotID == 0)
         {
-            return itemStack != null && !itemStack.isEmpty() && ItemElectricBase.isElectricItem(itemStack.getItem());
+            return !itemStack.isEmpty() && !itemStack.isEmpty() && ItemElectricBase.isElectricItem(itemStack.getItem());
         }
         else if (slotID >= 3)
         {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityFuelLoader.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityFuelLoader.java
@@ -173,7 +173,7 @@ public class TileEntityFuelLoader extends TileBaseElectricBlockWithInventory imp
     @Override
     public boolean canExtractItem(int slotID, ItemStack itemstack, EnumFacing side)
     {
-        if (slotID == 1 && itemstack != null)
+        if (slotID == 1 && !itemstack.isEmpty())
         {
             return FluidUtil.isEmptyContainer(itemstack);
         }
@@ -189,7 +189,7 @@ public class TileEntityFuelLoader extends TileBaseElectricBlockWithInventory imp
     @Override
     public boolean isItemValidForSlot(int slotID, ItemStack itemstack)
     {
-        return (slotID == 1 && itemstack != null && itemstack.getItem() == GCItems.fuelCanister) || (slotID == 0 ? ItemElectricBase.isElectricItem(itemstack.getItem()) : false);
+        return (slotID == 1 && !itemstack.isEmpty() && itemstack.getItem() == GCItems.fuelCanister) || (slotID == 0 ? ItemElectricBase.isElectricItem(itemstack.getItem()) : false);
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenCompressor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenCompressor.java
@@ -58,7 +58,7 @@ public class TileEntityOxygenCompressor extends TileEntityOxygen implements IInv
             {
                 ItemStack tank0 = this.stacks.get(0);
 
-                if (tank0 != null)
+                if (!tank0.isEmpty())
                 {
                     if (tank0.getItem() instanceof ItemOxygenTank && tank0.getItemDamage() > 0)
                     {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenStorageModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenStorageModule.java
@@ -279,7 +279,7 @@ public class TileEntityOxygenStorageModule extends TileEntityOxygen implements I
     @Override
     public boolean isItemValidForSlot(int slotID, ItemStack itemstack)
     {
-        return slotID == 0 && itemstack != null && itemstack.getItem() instanceof IItemOxygenSupply;
+        return slotID == 0 && !itemstack.isEmpty() && itemstack.getItem() instanceof IItemOxygenSupply;
     }
 
     //ISidedInventory
@@ -302,7 +302,7 @@ public class TileEntityOxygenStorageModule extends TileEntityOxygen implements I
     @Override
     public boolean canExtractItem(int slotID, ItemStack itemstack, EnumFacing side)
     {
-        if (slotID == 0 && itemstack != null)
+        if (slotID == 0 && !itemstack.isEmpty())
         {
             return FluidUtil.isEmptyContainer(itemstack);
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityRefinery.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityRefinery.java
@@ -209,7 +209,7 @@ public class TileEntityRefinery extends TileBaseElectricBlockWithInventory imple
     @Override
     public boolean canInsertItem(int slotID, ItemStack itemstack, EnumFacing side)
     {
-        if (itemstack != null && this.isItemValidForSlot(slotID, itemstack))
+        if (!itemstack.isEmpty() && this.isItemValidForSlot(slotID, itemstack))
         {
             switch (slotID)
             {
@@ -229,7 +229,7 @@ public class TileEntityRefinery extends TileBaseElectricBlockWithInventory imple
     @Override
     public boolean canExtractItem(int slotID, ItemStack itemstack, EnumFacing side)
     {
-        if (itemstack != null && this.isItemValidForSlot(slotID, itemstack))
+        if (!itemstack.isEmpty() && this.isItemValidForSlot(slotID, itemstack))
         {
             switch (slotID)
             {
@@ -252,7 +252,7 @@ public class TileEntityRefinery extends TileBaseElectricBlockWithInventory imple
         switch (slotID)
         {
         case 0:
-            return itemstack != null && ItemElectricBase.isElectricItem(itemstack.getItem());
+            return !itemstack.isEmpty() && ItemElectricBase.isElectricItem(itemstack.getItem());
         case 1:
         case 2:
             return FluidUtil.isValidContainer(itemstack);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/FluidUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/FluidUtil.java
@@ -242,7 +242,7 @@ public class FluidUtil
     public static void tryFillContainer(FluidTank tank, FluidStack liquid, NonNullList<ItemStack> inventory, int slot, Item canisterType)
     {
         ItemStack slotItem = inventory.get(slot);
-        if (liquid.amount <= 0 || slotItem == null)
+        if (liquid.amount <= 0 || slotItem.isEmpty())
         {
             return;
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/GCCoreUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/GCCoreUtil.java
@@ -411,12 +411,12 @@ public class GCCoreUtil
     public static ItemStack getMatchingItemEitherHand(EntityPlayer player, Item item)
     {
         ItemStack stack = player.inventory.getStackInSlot(player.inventory.currentItem);
-        if (stack != null && stack.getItem() == item)
+        if (!stack.isEmpty() && stack.getItem() == item)
         {
             return stack;
         }
         stack = player.inventory.offHandInventory.get(0);
-        if (stack != null && stack.getItem() == item)
+        if (!stack.isEmpty() && stack.getItem() == item)
         {
             return stack;
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/OxygenUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/OxygenUtil.java
@@ -350,7 +350,7 @@ public class OxygenUtil
 
         GCPlayerStats stats = GCPlayerStats.get(player);
 
-        if (stats.getExtendedInventory().getStackInSlot(0) == null || !OxygenUtil.isItemValidForPlayerTankInv(0, stats.getExtendedInventory().getStackInSlot(0)))
+        if (stats.getExtendedInventory().getStackInSlot(0).isEmpty() || !OxygenUtil.isItemValidForPlayerTankInv(0, stats.getExtendedInventory().getStackInSlot(0)))
         {
             boolean handled = false;
 
@@ -376,7 +376,7 @@ public class OxygenUtil
             }
         }
 
-        if (stats.getExtendedInventory().getStackInSlot(1) == null || !OxygenUtil.isItemValidForPlayerTankInv(1, stats.getExtendedInventory().getStackInSlot(1)))
+        if (stats.getExtendedInventory().getStackInSlot(1).isEmpty() || !OxygenUtil.isItemValidForPlayerTankInv(1, stats.getExtendedInventory().getStackInSlot(1)))
         {
             boolean handled = false;
 
@@ -402,7 +402,7 @@ public class OxygenUtil
             }
         }
 
-        if ((stats.getExtendedInventory().getStackInSlot(2) == null || !OxygenUtil.isItemValidForPlayerTankInv(2, stats.getExtendedInventory().getStackInSlot(2))) && (stats.getExtendedInventory().getStackInSlot(3) == null || !OxygenUtil.isItemValidForPlayerTankInv(3, stats.getExtendedInventory().getStackInSlot(3))))
+        if ((stats.getExtendedInventory().getStackInSlot(2).isEmpty() || !OxygenUtil.isItemValidForPlayerTankInv(2, stats.getExtendedInventory().getStackInSlot(2))) && (stats.getExtendedInventory().getStackInSlot(3).isEmpty() || !OxygenUtil.isItemValidForPlayerTankInv(3, stats.getExtendedInventory().getStackInSlot(3))))
         {
             boolean handled = false;
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/blocks/BlockIceAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/blocks/BlockIceAsteroids.java
@@ -70,7 +70,7 @@ public class BlockIceAsteroids extends BlockBreakable implements ISortableBlock
             ArrayList<ItemStack> items = new ArrayList<ItemStack>();
             ItemStack itemstack = this.getSilkTouchDrop(state);
 
-            if (itemstack != null)
+            if (!itemstack.isEmpty())
             {
                 items.add(itemstack);
             }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/recipe/CanisterRecipes.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/recipe/CanisterRecipes.java
@@ -91,7 +91,7 @@ public class CanisterRecipes extends ShapelessRecipes
         {
             ItemStack itemstack1 = inv.getStackInSlot(i);
 
-            if (itemstack1 != null && !itemstack1.isEmpty())
+            if (!itemstack1.isEmpty())
             {
                 Item testItem = itemstack1.getItem();
                 if (testItem instanceof ItemCanisterLiquidOxygen || testItem == GCItems.oxygenCanisterInfinite)

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/tile/TileEntityMinerBase.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/tile/TileEntityMinerBase.java
@@ -597,7 +597,7 @@ public class TileEntityMinerBase extends TileBaseElectricBlockWithInventory impl
         if (this.isMaster)
         {
             ItemStack holding = entityPlayer.getActiveItemStack();
-            if (holding != null && holding.getItem() == AsteroidsItems.astroMiner)
+            if (!holding.isEmpty() && holding.getItem() == AsteroidsItems.astroMiner)
             {
                 return false;
             }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/blocks/BlockCreeperEgg.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/blocks/BlockCreeperEgg.java
@@ -121,7 +121,7 @@ public class BlockCreeperEgg extends BlockDragonEgg implements IShiftDescription
     public float getPlayerRelativeBlockHardness(IBlockState state, EntityPlayer player, World worldIn, BlockPos pos)
     {
         ItemStack stack = player.inventory.getCurrentItem();
-        if (stack != null && stack.getItem() == MarsItems.deshPickSlime)
+        if (!stack.isEmpty() && stack.getItem() == MarsItems.deshPickSlime)
         {
             return 0.2F;
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/blocks/BlockSlimelingEgg.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/blocks/BlockSlimelingEgg.java
@@ -144,7 +144,7 @@ public class BlockSlimelingEgg extends Block implements ITileEntityProvider, ISh
     public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player, boolean willHarvest)
     {
         ItemStack currentStack = player.getHeldItemMainhand();
-        if (currentStack != null && currentStack.getItem() instanceof ItemPickaxe)
+        if (!currentStack.isEmpty() && currentStack.getItem() instanceof ItemPickaxe)
         {
             return world.setBlockToAir(pos);
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/gui/GuiSlimeling.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/gui/GuiSlimeling.java
@@ -200,7 +200,7 @@ public class GuiSlimeling extends GuiScreen
         GlStateManager.popMatrix();
         ItemStack foodStack = new ItemStack(this.slimeling.getFavoriteFood());
 
-        if (foodStack != null && mouseX >= this.invX - 66 && mouseX < this.invX + this.invWidth - 68 && mouseY >= this.invY + 44 && mouseY < this.invY + this.invHeight + 42)
+        if (!foodStack.isEmpty() && mouseX >= this.invX - 66 && mouseX < this.invX + this.invWidth - 68 && mouseY >= this.invY + 44 && mouseY < this.invY + this.invHeight + 42)
         {
             this.renderToolTip(foodStack, mouseX, mouseY);
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntitySlimeling.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntitySlimeling.java
@@ -405,7 +405,7 @@ public class EntitySlimeling extends EntityTameable implements IEntityBreathable
 
         if (this.isTamed())
         {
-            if (itemstack != null)
+            if (!itemstack.isEmpty())
             {
                 if (itemstack.getItem() == this.getFavoriteFood())
                 {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/venus/blocks/BlockBasicVenus.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/venus/blocks/BlockBasicVenus.java
@@ -120,7 +120,7 @@ public class BlockBasicVenus extends Block implements IDetectableResource, IPlan
             ArrayList<ItemStack> items = new ArrayList<ItemStack>();
             ItemStack itemstack = this.getSilkTouchDrop(state);
 
-            if (itemstack != null)
+            if (!itemstack.isEmpty())
             {
                 items.add(itemstack);
             }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/venus/items/ItemBasicVenus.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/venus/items/ItemBasicVenus.java
@@ -99,7 +99,7 @@ public class ItemBasicVenus extends ItemDesc implements ISortableItem
             GCPlayerStats stats = GCPlayerStats.get(player);
             ItemStack gear = stats.getExtendedInventory().getStackInSlot(10);
 
-            if (gear == null)
+            if (gear.isEmpty())
             {
                 stats.getExtendedInventory().setInventorySlotContents(10, itemStack.copy());
                 itemStack.setCount(0);

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/venus/items/ItemThermalPaddingTier2.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/venus/items/ItemThermalPaddingTier2.java
@@ -121,7 +121,7 @@ public class ItemThermalPaddingTier2 extends Item implements IItemThermal, ISort
 
             if (itemStack.getItemDamage() == 0)
             {
-                if (gear == null)
+                if (gear.isEmpty())
                 {
                     stats.getExtendedInventory().setInventorySlotContents(6, itemStack.copy());
                     itemStack.setCount(0);
@@ -129,7 +129,7 @@ public class ItemThermalPaddingTier2 extends Item implements IItemThermal, ISort
             }
             else if (itemStack.getItemDamage() == 1)
             {
-                if (gear1 == null)
+                if (gear1.isEmpty())
                 {
                     stats.getExtendedInventory().setInventorySlotContents(7, itemStack.copy());
                     itemStack.setCount(0);
@@ -137,7 +137,7 @@ public class ItemThermalPaddingTier2 extends Item implements IItemThermal, ISort
             }
             else if (itemStack.getItemDamage() == 2)
             {
-                if (gear2 == null)
+                if (gear2.isEmpty())
                 {
                     stats.getExtendedInventory().setInventorySlotContents(8, itemStack.copy());
                     itemStack.setCount(0);
@@ -145,7 +145,7 @@ public class ItemThermalPaddingTier2 extends Item implements IItemThermal, ISort
             }
             else if (itemStack.getItemDamage() == 3)
             {
-                if (gear3 == null)
+                if (gear3.isEmpty())
                 {
                     stats.getExtendedInventory().setInventorySlotContents(9, itemStack.copy());
                     itemStack.setCount(0);


### PR DESCRIPTION
I'm not sure how up to date this Repo is with the current GC 1.12 code base, but if it can help I noticed a few null checks with ItemStacks that didn't seem to be working properly.

 - Replaced ItemStack == null checks with ItemStack.isEmpty()
    - ItemStack == null is always false
 - Replaced ItemStack !=null checks with !ItemStack.isEmpty()
   - ItemStack != null is always true
 - Removed duplicate ItemStack != null && !ItemStack.isEmpty() checks