### PR TITLE
Fix Inventory Texture Error of Moon Block #3469

### DIFF
--- a/src/main/resources/assets/galacticraftcore/blockstates/basic_block_moon.json
+++ b/src/main/resources/assets/galacticraftcore/blockstates/basic_block_moon.json
@@ -1,7 +1,7 @@
 {
     "forge_marker": 1,
     "variants": {
-        "inventory": [{ "model": "galacticraftcore:ore_copper_moon_model" }],
+        "inventory": [{ "model": "galacticraftcore:basic_block_moon" }],
         "basictypemoon=ore_copper_moon": { "model": "galacticraftcore:ore_copper_moon_model" },
         "basictypemoon=ore_tin_moon": { "model": "galacticraftcore:ore_tin_moon_model" },
         "basictypemoon=ore_cheese_moon": { "model": "galacticraftcore:ore_cheese_moon_model" },


### PR DESCRIPTION
This is a possible fix to the error of the moon rock's inventory model being set to the moon copper ore's model. Issue #3469 