### PR TITLE
1.12.2 only, Changed GC Planets registering recipes to match GC Core system

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -46,6 +46,9 @@ import micdoodle8.mods.galacticraft.core.world.gen.BiomeOrbit;
 import micdoodle8.mods.galacticraft.core.world.gen.OreGenOtherMods;
 import micdoodle8.mods.galacticraft.core.world.gen.OverworldGenerator;
 import micdoodle8.mods.galacticraft.planets.GalacticraftPlanets;
+import micdoodle8.mods.galacticraft.planets.asteroids.recipe.RecipeManagerAsteroids;
+import micdoodle8.mods.galacticraft.planets.mars.recipe.RecipeManagerMars;
+import micdoodle8.mods.galacticraft.planets.venus.recipe.RecipeManagerVenus;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
@@ -737,6 +740,12 @@ public class GalacticraftCore
         {
             RecipeManagerGC.addUniversalRecipes();
             RecipeManagerGC.setConfigurableRecipes();
+            if (isPlanetsLoaded)
+            {
+            	RecipeManagerAsteroids.addUniversalRecipes();
+            	RecipeManagerMars.addUniversalRecipes();
+            	RecipeManagerVenus.addUniversalRecipes();
+            }
         }
 
         @SubscribeEvent

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
@@ -154,7 +154,7 @@ public class AsteroidsModule implements IPlanetsModule
 
         this.registerEntities();
 
-        RecipeManagerAsteroids.loadRecipes();
+        RecipeManagerAsteroids.loadCompatibilityRecipes();
 
         AsteroidsModule.planetAsteroids.setDimensionInfo(ConfigManagerAsteroids.dimensionIDAsteroids, WorldProviderAsteroids.class).setTierRequired(3);
         AsteroidsModule.planetAsteroids.setRelativeDistanceFromCenter(new CelestialBody.ScalableDistance(1.375F, 1.375F)).setRelativeOrbitTime(45.0F).setPhaseShift((float) (Math.random() * (2 * Math.PI)));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/recipe/RecipeManagerAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/recipe/RecipeManagerAsteroids.java
@@ -16,14 +16,7 @@ import net.minecraft.util.NonNullList;
 
 public class RecipeManagerAsteroids
 {
-    public static void loadRecipes()
-    {
-        // Add compatibility stuffz here
-
-        addUniversalRecipes();
-    }
-
-    private static void addUniversalRecipes()
+    public static void addUniversalRecipes()
     {
         ItemStack titaniumIngot = new ItemStack(AsteroidsItems.basicItem, 1, 0);
     	ItemStack platingTier3 = new ItemStack(AsteroidsItems.basicItem, 1, 5);
@@ -64,7 +57,11 @@ public class RecipeManagerAsteroids
         RecipeUtil.addCustomRecipe(new CanisterRecipes(new ItemStack(GCItems.oxTankHeavy, 1, 0), list1));
         RecipeUtil.addCustomRecipe(new CanisterRecipes(new ItemStack(GCItems.oxTankMedium, 1, 0), list2));
         RecipeUtil.addCustomRecipe(new CanisterRecipes(new ItemStack(GCItems.oxTankLight, 1, 0), list3));
-        
+    }
+    
+    public static void loadCompatibilityRecipes()
+    {
+        ItemStack titaniumIngot = new ItemStack(AsteroidsItems.basicItem, 1, 0);
         if (CompatibilityManager.isIc2Loaded())
         {
             CompatModuleIC2Asteroids.addIC2Recipes(titaniumIngot, new ItemStack(AsteroidsItems.basicItem, 1, 9));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
@@ -158,7 +158,7 @@ public class MarsModule implements IPlanetsModule
     @Override
     public void postInit(FMLPostInitializationEvent event)
     {
-        RecipeManagerMars.loadRecipes();
+        RecipeManagerMars.loadCompatibilityRecipes();
         GCPlanetDimensions.MARS = WorldUtil.getDimensionTypeById(ConfigManagerMars.dimensionIDMars);
         ItemSchematicTier2.registerSchematicItems();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/recipe/RecipeManagerMars.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/recipe/RecipeManagerMars.java
@@ -14,12 +14,11 @@ import java.util.HashMap;
 
 public class RecipeManagerMars
 {
-    public static void loadRecipes()
+	public static void loadCompatibilityRecipes()
     {
-        RecipeManagerMars.addUniversalRecipes();
     }
 
-    private static void addUniversalRecipes()
+    public static void addUniversalRecipes()
     {
         OreDictionary.registerOre("ingotDesh", new ItemStack(MarsItems.marsItemBasic, 1, 2));
         OreDictionary.registerOre("compressedDesh", new ItemStack(MarsItems.marsItemBasic, 1, 5));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/venus/VenusModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/venus/VenusModule.java
@@ -151,7 +151,7 @@ public class VenusModule implements IPlanetsModule
     @Override
     public void postInit(FMLPostInitializationEvent event)
     {
-        RecipeManagerVenus.loadRecipes();
+        RecipeManagerVenus.loadCompatibilityRecipes();
 
         GCPlanetDimensions.VENUS = WorldUtil.getDimensionTypeById(ConfigManagerVenus.dimensionIDVenus);
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/venus/recipe/RecipeManagerVenus.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/venus/recipe/RecipeManagerVenus.java
@@ -10,12 +10,11 @@ import net.minecraftforge.oredict.OreDictionary;
 
 public class RecipeManagerVenus
 {
-    public static void loadRecipes()
+	public static void loadCompatibilityRecipes()
     {
-        RecipeManagerVenus.addUniversalRecipes();
     }
 
-    private static void addUniversalRecipes()
+    public static void addUniversalRecipes()
     {
         OreDictionary.registerOre("ingotLead", new ItemStack(VenusItems.basicItem, 1, 1));
 


### PR DESCRIPTION
Fixes https://github.com/micdoodle8/Galacticraft/issues/3514

This pull requests move everything that isnt mod compact recipes to the RegistryEvent.Register<IRecipe> event to match the GC Core which already has this. 

I need this to fix GalacticraftTweaker issues
https://github.com/MJRLegends/GalacticraftTweaker/issues/4
https://github.com/MJRLegends/GalacticraftTweaker/issues/6

Would be amazing if it could be merged 