### PR TITLE
Added OreDictionary value for Cheese Curd

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/GCItems.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GCItems.java
@@ -169,6 +169,7 @@ public class GCItems
             }
         }
 
+        OreDictionary.registerOre("foodCheese", new ItemStack(GCItems.cheeseCurd, 1, 0));
         OreDictionary.registerOre("compressedMeteoricIron", new ItemStack(GCItems.itemBasicMoon, 1, 1));
         OreDictionary.registerOre("ingotMeteoricIron", new ItemStack(GCItems.itemBasicMoon, 1, 0));
         if (CompatibilityManager.useAluDust())


### PR DESCRIPTION
Whilst using food mods such as Pam's Harvestcraft Galacticraft Cheese cannot be used in recipes.