### PR TITLE
Added planet.venus

### DIFF
--- a/src/main/resources/assets/galacticraftplanets/lang/en_US.lang
+++ b/src/main/resources/assets/galacticraftplanets/lang/en_US.lang
@@ -271,6 +271,7 @@ item.volcanic_pickaxe.description=Mines a 3x3 area depending on which direction 
 item.volcanic_pickaxe.name=Volcanic Pickaxe
 planet.asteroids=Asteroids
 planet.mars=Mars
+planet.venus=Venus
 schematic.astro_miner.name=Astro Miner
 schematic.cargo_rocket.name=Automatic Cargo Rocket
 schematic.rocket_t3.name=Tier 3 Rocket


### PR DESCRIPTION
Saw that planet.venus=Venus was missing, fixed. Will be used in [SurvivalPlus](https://github.com/coolsimulations/SurvivalPlus). Also, is there an easier way to distribute this change across 1.10-1.12 branches without making multiple new pull requests?