### PR TITLE
Update "versionRev" to 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 def mcVersion = "1.8.9"
 def versionMajor = 4
 def versionMinor = 0
-def versionRev = 1
+def versionRev = 2
 
 // For those who want the bleeding edge
 buildscript {


### PR DESCRIPTION
I couldn't really find a appropriate place to put this, so I just made this PR. It just updates the revision/patch version to 2 to match the mod's metadata (So that the file's version matches the mod's version.

Edit: While the topic is still sort-of on `build.gradle` - Why do you guys use a `dependencies/` folder instead of using maven repos?