### PR TITLE
Disable enchants on special items with durability (Fix #3626)

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemBattery.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemBattery.java
@@ -27,6 +27,9 @@ public class ItemBattery extends ItemElectricBase implements ISortableItem
     }
 
     @Override
+    public boolean isBookEnchantable(ItemStack item, ItemStack book) { return false; }
+
+    @Override
     @SideOnly(Side.CLIENT)
     public EnumRarity getRarity(ItemStack par1ItemStack)
     {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemCanisterGeneric.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemCanisterGeneric.java
@@ -192,7 +192,6 @@ public abstract class ItemCanisterGeneric extends ItemFluidContainer
     private void replaceEmptyCanisterItem(ItemStack container, Item newItem)
     {
         //This is a neat trick to change the item ID in an ItemStack
-        //This is a neat trick to change the item ID in an ItemStack
         final int stackSize = container.stackSize;
         NBTTagCompound tag = new NBTTagCompound();
         container.writeToNBT(tag);
@@ -219,4 +218,7 @@ public abstract class ItemCanisterGeneric extends ItemFluidContainer
 
         return new FluidStack(fluid, ItemCanisterGeneric.EMPTY - container.getItemDamage());
     }
+    
+    @Override
+    public boolean isBookEnchantable(ItemStack item, ItemStack book) { return false; }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemFuelCanister.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemFuelCanister.java
@@ -70,4 +70,7 @@ public class ItemFuelCanister extends ItemCanisterGeneric implements ISortableIt
     {
         return EnumSortCategoryItem.CANISTER;
     }
+
+    @Override
+    public boolean isBookEnchantable(ItemStack item, ItemStack book) { return false; }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemOilCanister.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemOilCanister.java
@@ -101,4 +101,7 @@ public class ItemOilCanister extends ItemCanisterGeneric implements ISortableIte
     {
         return EnumSortCategoryItem.CANISTER;
     }
+
+    @Override
+    public boolean isBookEnchantable(ItemStack item, ItemStack book) { return false; }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemOxygenTank.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemOxygenTank.java
@@ -36,6 +36,12 @@ public class ItemOxygenTank extends Item implements ISortableItem
     }
 
     @Override
+    public boolean isBookEnchantable(ItemStack item, ItemStack book)
+    {
+        return false;
+    }
+
+    @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List<ItemStack> par3List)
     {


### PR DESCRIPTION
Note: To be tested on 1.10+ (but I'm pretty sure the method has not changed)