### PR TITLE
Fix name not being included

### DIFF
--- a/capes.txt
+++ b/capes.txt
@@ -103,3 +103,4 @@ Timsuper2:capeOrange
 Sonic_Blender:capeLightGray
 xX_CreeperMr_Xx:capeRainbow
 Santiv:capePurple
+SebaSphere:capeRainbow


### PR DESCRIPTION
Confused why cape isn't included under list when confirmed in discord DM's?

https://cdn.discordapp.com/attachments/556637004197003294/560691230414209055/unknown.png

@marcus8448 is currently working on adding the cape system to Galacticraft Fabric and I got confused when I saw I wasn't in it :p