### PR TITLE
Add an option to disable small asteroids entirely

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/ConfigManagerAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/ConfigManagerAsteroids.java
@@ -115,7 +115,6 @@ public class ConfigManagerAsteroids
             astroMinerMax = prop.getInt(6);
             GalacticraftPlanets.finishProp(prop, Constants.CONFIG_CATEGORY_GENERAL);
 
-            //
             prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "disableSmallAsteroids", false);
             prop.setComment("Option to disable small asteroids from spawning in the Asteroids Dimension.");
             prop.setLanguageKey("gc.configgui.disable_small_asteroids");
@@ -126,7 +125,6 @@ public class ConfigManagerAsteroids
             }
             disableSmallAsteroids = prop.getBoolean(false);
             GalacticraftPlanets.finishProp(prop, Constants.CONFIG_CATEGORY_GENERAL);
-            //
 
             prop = config.get(update ? Constants.CONFIG_CATEGORY_GENERAL : Constants.CONFIG_CATEGORY_WORLDGEN, "Disable Iron Ore Gen on Asteroids", false);
             prop.setComment("Disable Iron Ore Gen on Asteroids.");

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/ConfigManagerAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/ConfigManagerAsteroids.java
@@ -46,6 +46,7 @@ public class ConfigManagerAsteroids
 
     // GENERAL
     public static boolean disableGalacticraftHelium;
+    public static boolean disableSmallAsteroids;
     public static int astroMinerMax;
 
     public static boolean disableIlmeniteGen;
@@ -113,6 +114,19 @@ public class ConfigManagerAsteroids
             }
             astroMinerMax = prop.getInt(6);
             GalacticraftPlanets.finishProp(prop, Constants.CONFIG_CATEGORY_GENERAL);
+
+            //
+            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "disableSmallAsteroids", false);
+            prop.setComment("Option to disable small asteroids from spawning in the Asteroids Dimension.");
+            prop.setLanguageKey("gc.configgui.disable_small_asteroids");
+            if (update)
+            {
+                propCopy = ConfigManagerMars.config.get(Constants.CONFIG_CATEGORY_GENERAL, prop.getName(), prop.getBoolean(), prop.getComment());
+                propCopy.setLanguageKey(prop.getLanguageKey());
+            }
+            disableSmallAsteroids = prop.getBoolean(false);
+            GalacticraftPlanets.finishProp(prop, Constants.CONFIG_CATEGORY_GENERAL);
+            //
 
             prop = config.get(update ? Constants.CONFIG_CATEGORY_GENERAL : Constants.CONFIG_CATEGORY_WORLDGEN, "Disable Iron Ore Gen on Asteroids", false);
             prop.setComment("Disable Iron Ore Gen on Asteroids.");

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/entities/player/AsteroidsPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/entities/player/AsteroidsPlayerHandler.java
@@ -1,5 +1,6 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.entities.player;
 
+import micdoodle8.mods.galacticraft.planets.asteroids.ConfigManagerAsteroids;
 import micdoodle8.mods.galacticraft.planets.asteroids.dimension.WorldProviderAsteroids;
 import micdoodle8.mods.galacticraft.planets.asteroids.entities.EntitySmallAsteroid;
 import net.minecraft.entity.player.EntityPlayer;
@@ -62,36 +63,35 @@ public class AsteroidsPlayerHandler
 
     public void onPlayerUpdate(EntityPlayerMP player)
     {
-        if (!player.world.isRemote && player.world.provider instanceof WorldProviderAsteroids)
-        {
-            final int f = 50;
+        if (!ConfigManagerAsteroids.disableSmallAsteroids) {
+            if (!player.world.isRemote && player.world.provider instanceof WorldProviderAsteroids) {
+                final int f = 50;
 
-            if (player.world.rand.nextInt(f) == 0 && player.posY < 260D)
-            {
-                final EntityPlayer closestPlayer = player.world.getClosestPlayerToEntity(player, 100);
+                if (player.world.rand.nextInt(f) == 0 && player.posY < 260D) {
+                    final EntityPlayer closestPlayer = player.world.getClosestPlayerToEntity(player, 100);
 
-                if (closestPlayer == null || closestPlayer.getEntityId() <= player.getEntityId())
-                {
-                    double x, y, z;
-                    double motX, motY, motZ;
-                    double r = player.world.rand.nextInt(60) + 30D;
-                    double theta = Math.PI * 2.0 * player.world.rand.nextDouble();
-                    x = player.posX + Math.cos(theta) * r;
-                    y = player.posY + player.world.rand.nextInt(5);
-                    z = player.posZ + Math.sin(theta) * r;
-                    motX = (player.posX - x + (player.world.rand.nextDouble() - 0.5) * 40) / 400.0F;
-                    motY = (player.world.rand.nextDouble() - 0.5) * 0.4;
-                    motZ = (player.posZ - z + (player.world.rand.nextDouble() - 0.5) * 40) / 400.0F;
+                    if (closestPlayer == null || closestPlayer.getEntityId() <= player.getEntityId()) {
+                        double x, y, z;
+                        double motX, motY, motZ;
+                        double r = player.world.rand.nextInt(60) + 30D;
+                        double theta = Math.PI * 2.0 * player.world.rand.nextDouble();
+                        x = player.posX + Math.cos(theta) * r;
+                        y = player.posY + player.world.rand.nextInt(5);
+                        z = player.posZ + Math.sin(theta) * r;
+                        motX = (player.posX - x + (player.world.rand.nextDouble() - 0.5) * 40) / 400.0F;
+                        motY = (player.world.rand.nextDouble() - 0.5) * 0.4;
+                        motZ = (player.posZ - z + (player.world.rand.nextDouble() - 0.5) * 40) / 400.0F;
 
-                    final EntitySmallAsteroid smallAsteroid = new EntitySmallAsteroid(player.world);
-                    smallAsteroid.setPosition(x, y, z);
-                    smallAsteroid.motionX = motX;
-                    smallAsteroid.motionY = motY;
-                    smallAsteroid.motionZ = motZ;
-                    smallAsteroid.spinYaw = player.world.rand.nextFloat() * 4;
-                    smallAsteroid.spinPitch = player.world.rand.nextFloat() * 2;
+                        final EntitySmallAsteroid smallAsteroid = new EntitySmallAsteroid(player.world);
+                        smallAsteroid.setPosition(x, y, z);
+                        smallAsteroid.motionX = motX;
+                        smallAsteroid.motionY = motY;
+                        smallAsteroid.motionZ = motZ;
+                        smallAsteroid.spinYaw = player.world.rand.nextFloat() * 4;
+                        smallAsteroid.spinPitch = player.world.rand.nextFloat() * 2;
 
-                    player.world.spawnEntity(smallAsteroid);
+                        player.world.spawnEntity(smallAsteroid);
+                    }
                 }
             }
         }

--- a/src/main/resources/assets/galacticraftplanets/lang/en_US.lang
+++ b/src/main/resources/assets/galacticraftplanets/lang/en_US.lang
@@ -56,6 +56,7 @@ gc.configgui.disable_ambient_lightning=Disable Lightning (Venus)
 gc.configgui.disable_copper_gen_mars=Disable Copper Ore Gen (Mars)
 gc.configgui.disable_desh_gen_mars=Disable Desh Ore Gen (Mars)
 gc.configgui.disable_galacticraft_helium=Disable Helium gas registration
+gc.configgui.disable_small_asteroids=Disable Small Asteroid spawning (Asteroids)
 gc.configgui.disable_ilmenite_gen_asteroids=Disable Ilmenite Ore Gen (Asteroids)
 gc.configgui.disable_iron_gen_asteroids=Disable Iron Ore Gen (Asteroids)
 gc.configgui.disable_iron_gen_mars=Disable Iron Ore Gen (Mars)


### PR DESCRIPTION
A handful of server owners on the GC discord seem to still have lag problems with small asteroids, even after https://github.com/micdoodle8/Galacticraft/commit/579479ab4a64b0133177b552602c290c6a196cc3, so I made a config option to disable the asteroids entirely.