### PR TITLE
Only initialize render lists in SkyProviderOrbit once (fix client memory leak, greatly improve space station FPS)

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/SkyProviderOrbit.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/SkyProviderOrbit.java
@@ -24,9 +24,12 @@ public class SkyProviderOrbit extends IRenderHandler
     private static final ResourceLocation moonTexture = new ResourceLocation("textures/environment/moon_phases.png");
     private static final ResourceLocation sunTexture = new ResourceLocation(Constants.ASSET_PREFIX, "textures/gui/planets/orbitalsun.png");
 
-    public int starGLCallList = GLAllocation.generateDisplayLists(3);
-    public int glSkyList;
-    public int glSkyList2;
+    /* These are created once, then re-used */
+    public static boolean displayListsInitialized = false;
+    public static int starGLCallList;
+    public static int glSkyList;
+    public static int glSkyList2;
+
     private final ResourceLocation planetToRender;
     private final boolean renderMoon;
     private final boolean renderSun;
@@ -40,6 +43,15 @@ public class SkyProviderOrbit extends IRenderHandler
         this.planetToRender = planet;
         this.renderMoon = renderMoon;
         this.renderSun = renderSun;
+
+        if (!displayListsInitialized) {
+            initializeDisplayLists();
+        }
+    }
+
+    private void initializeDisplayLists() {
+        starGLCallList = GLAllocation.generateDisplayLists(3);
+
         GL11.glPushMatrix();
         GL11.glNewList(this.starGLCallList, GL11.GL_COMPILE);
         this.renderStars();
@@ -85,6 +97,8 @@ public class SkyProviderOrbit extends IRenderHandler
 
         tessellator.draw();
         GL11.glEndList();
+
+        displayListsInitialized = true;
     }
 
     private final Minecraft minecraft = FMLClientHandler.instance().getClient();


### PR DESCRIPTION
After much debugging, figured out that SkyProviderOrbit is being instantiated many times. It seems like it was originally designed to be instantiated once/a small number of times, then render() called on it many times.

Instantiating this class many, many times was leading to a memory leak where many copies of the openGL display lists were instantiated but never free'd.

This patch changes those display lists to only instantiate once and be re-used by any subsequent instance of SkyProviderOrbit. This should fix the memory leak and improve overall rendering performance.


Somewhat anecdotal, but this brings my FPS from ~20 to my monitor's 120 vsync. The sky still animates on my space station... seems to work well but not sure how else to test this.